### PR TITLE
CB-6899 "Cordova-lib link" step fails on Windows slave

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -170,7 +170,7 @@ cli_steps = [
     ShellCommand(command=["git","clone",repos['CLI'],"cordova-cli"],workdir='build',haltOnFailure=True,description='Get CLI',descriptionDone='Get CLI'),
     ShellCommand(command=["mkdir","node_modules"],workdir='build/cordova-cli',haltOnFailure=True,description='prepare cordova-lib',descriptionDone='Prepare cordova-lib'),
     ShellCommand(command=[shellCmd,shellRunParam, "git clone -b " + branches['CORDOVA-LIB']  + ' ' + repos['CORDOVA-LIB'] + " cordova-lib"],workdir='build',haltOnFailure=True,description='Update Cordova-lib',descriptionDone='Update Cordova-lib'),
-    ShellCommand(command=[shellCmd,shellRunParam,"ln -s ../../cordova-lib/cordova-lib cordova-lib"],workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
+    ShellCommand(command=["node", "-e", "require('fs').symlinkSync('../../cordova-lib/cordova-lib', 'cordova-lib', 'dir')"], workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
     ShellCommand(command=["npm","install","--production"], workdir='build/cordova-cli/node_modules/cordova-lib',haltOnFailure=True,description='Install Cordova-lib',descriptionDone='Install Cordova-lib'),
     ShellCommand(command=["rm","-f", "npm-shrinkwrap.json"],workdir='build/cordova-cli',haltOnFailure=False,description='Remove CLI SW',descriptionDone='Remove CLI SW'),
     ShellCommand(command=["npm","install"],workdir='build/cordova-cli',haltOnFailure=True,description='Install CLI',descriptionDone='Install CLI'),
@@ -201,7 +201,7 @@ common_steps_1 = [
 common_steps_mobilespec_1 = [
     ShellCommand(command=["mkdir","node_modules"],workdir='build/cordova-cli',haltOnFailure=True,description='prepare cordova-lib',descriptionDone='Prepare cordova-lib'),
     ShellCommand(command=[shellCmd,shellRunParam, "git clone -b " + branches['CORDOVA-LIB']  + ' ' + repos['CORDOVA-LIB'] + " cordova-lib"],workdir='build',haltOnFailure=True,description='Update Cordova-lib',descriptionDone='Update Cordova-lib'),
-    ShellCommand(command=[shellCmd,shellRunParam,"ln -s ../../cordova-lib/cordova-lib cordova-lib"],workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
+    ShellCommand(command=["node", "-e", "require('fs').symlinkSync('../../cordova-lib/cordova-lib', 'cordova-lib', 'dir')"], workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
     ShellCommand(command=["npm","install","--production"], workdir='build/cordova-cli/node_modules/cordova-lib',haltOnFailure=True,description='Install Cordova-lib',descriptionDone='Install Cordova-lib'),
     ShellCommand(command=["rm","-f", "npm-shrinkwrap.json"],workdir='build/cordova-cli',haltOnFailure=False,description='Remove CLI SW',descriptionDone='Remove CLI SW'),
     ShellCommand(command=["sed","-e","s/cordova-lib\": \"0./cordova-lib\": \">=0./","-i","bak","package.json"],workdir='build/cordova-cli',haltOnFailure=True,description='Edit json',descriptionDone='Edit json'),
@@ -210,7 +210,7 @@ common_steps_mobilespec_1 = [
 ]
 
 # The steps for any platform after platform add
-copy_www_cmd = ShellCommand(command=["ln","-s","../cordova-mobile-spec","www"],workdir='build/mobilespec',haltOnFailure=True,description ='Link www',descriptionDone ='Link www')
+copy_www_cmd = ShellCommand(command=["node", "-e", "require('fs').symlinkSync('../cordova-mobile-spec','www','dir')"], workdir='build/mobilespec',haltOnFailure=True,description='Link www', descriptionDone='Link www'),
 if is_Windows :
     copy_www_cmd=ShellCommand(command=["cp","-r","../cordova-mobile-spec","www"],workdir='build\\mobilespec',haltOnFailure=True,description ='Copy www',descriptionDone ='Copy www')
 common_steps_mobilespec_2 = [


### PR DESCRIPTION
Replaces "ln -s" command, which is not workin on windows slaves, with inline node script.
Fix for [CB-6899](https://issues.apache.org/jira/browse/CB-6899)
