### PR TITLE
CB-6889 "Edit json" step in master.cfg fails on Windows

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -204,7 +204,7 @@ common_steps_mobilespec_1 = [
     ShellCommand(command=[shellCmd,shellRunParam,"ln -s ../../cordova-lib/cordova-lib cordova-lib"],workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
     ShellCommand(command=["npm","install","--production"], workdir='build/cordova-cli/node_modules/cordova-lib',haltOnFailure=True,description='Install Cordova-lib',descriptionDone='Install Cordova-lib'),
     ShellCommand(command=["rm","-f", "npm-shrinkwrap.json"],workdir='build/cordova-cli',haltOnFailure=False,description='Remove CLI SW',descriptionDone='Remove CLI SW'),
-    ShellCommand(command=["sed","-e","s/cordova-lib\": \"0./cordova-lib\": \">=0./","-i","bak","package.json"],workdir='build/cordova-cli',haltOnFailure=True,description='Edit json',descriptionDone='Edit json'),
+    ShellCommand(command=["sed","-e","s/cordova-lib\": \"0./cordova-lib\": \">=0./","-ibak","package.json"],workdir='build/cordova-cli',haltOnFailure=True,description='Edit json',descriptionDone='Edit json'),
     ShellCommand(command=["npm","install","--production"],workdir='build/cordova-cli',haltOnFailure=True,description='Install CLI',descriptionDone='Install CLI'),
     ShellCommand(command=["node", "cordova-cli/bin/cordova","create","mobilespec","org.apache.mobilespec","mobilespec"],workdir='build',haltOnFailure=True, description='CLI Create', descriptionDone='CLI Create')
 ]


### PR DESCRIPTION
When running medic on windows (either the client and server or just a client), the Edit json step specified in master.cfg fails.
_Reason:_ Windows medic install uses the unix utilities from git\bin, the version of sed installed requires specification of backup suffix for -i option without space.

```
  -i[SUFFIX], --in-place[=SUFFIX]
                 edit files in place (makes backup if extension supplied)
```

from sed help.

Fix for [CB-6889](https://issues.apache.org/jira/browse/CB-6889)
