### PR TITLE
CB-6909 shellCmd and shellRunParam in master.cfg use values for master, fails on Windows slaves if OS X master

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -159,18 +159,12 @@ from buildbot.steps.source.git import Git
 from buildbot.steps.shell import ShellCommand
 from buildbot.config import BuilderConfig
 
-shellCmd="/bin/sh"
-shellRunParam="-c"
-if is_Windows :
-    shellCmd="cmd"
-    shellRunParam="/c"
-
 cli_steps = [
-    ShellCommand(command=[shellCmd,shellRunParam,"rm -rf cordova-*"],workdir='build',haltOnFailure=False,description='Cordova Clean', descriptionDone='Cordova Clean'),
+    ShellCommand(command=["rm","-rf","cordova-*"],workdir='build',haltOnFailure=False,description='Cordova Clean', descriptionDone='Cordova Clean'),
     ShellCommand(command=["git","clone",repos['CLI'],"cordova-cli"],workdir='build',haltOnFailure=True,description='Get CLI',descriptionDone='Get CLI'),
     ShellCommand(command=["mkdir","node_modules"],workdir='build/cordova-cli',haltOnFailure=True,description='prepare cordova-lib',descriptionDone='Prepare cordova-lib'),
-    ShellCommand(command=[shellCmd,shellRunParam, "git clone -b " + branches['CORDOVA-LIB']  + ' ' + repos['CORDOVA-LIB'] + " cordova-lib"],workdir='build',haltOnFailure=True,description='Update Cordova-lib',descriptionDone='Update Cordova-lib'),
-    ShellCommand(command=[shellCmd,shellRunParam,"ln -s ../../cordova-lib/cordova-lib cordova-lib"],workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
+    ShellCommand(command=["git","clone -b",branches['CORDOVA-LIB'],repos['CORDOVA-LIB'],"cordova-lib"],workdir='build',haltOnFailure=True,description='Update Cordova-lib',descriptionDone='Update Cordova-lib'),
+    ShellCommand(command=["ln","-s","../../cordova-lib/cordova-lib","cordova-lib"], workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
     ShellCommand(command=["npm","install","--production"], workdir='build/cordova-cli/node_modules/cordova-lib',haltOnFailure=True,description='Install Cordova-lib',descriptionDone='Install Cordova-lib'),
     ShellCommand(command=["rm","-f", "npm-shrinkwrap.json"],workdir='build/cordova-cli',haltOnFailure=False,description='Remove CLI SW',descriptionDone='Remove CLI SW'),
     ShellCommand(command=["npm","install"],workdir='build/cordova-cli',haltOnFailure=True,description='Install CLI',descriptionDone='Install CLI'),
@@ -178,7 +172,7 @@ cli_steps = [
 ]
 
 plugman_steps = [
-    ShellCommand(command=[shellCmd,shellRunParam,"rm -rf cordova-*"],workdir='build',haltOnFailure=False,description='Cordova Clean', descriptionDone='Cordova Clean'),
+    ShellCommand(command=["rm","-rf","cordova-*"],workdir='build',haltOnFailure=False,description='Cordova Clean', descriptionDone='Cordova Clean'),
     ShellCommand(command=["git","clone",repos['PLUGMAN'],"cordova-plugman"],workdir='build',haltOnFailure=True,description='Get Plugman',descriptionDone='Get Plugman'),
     ShellCommand(command=["npm","install"], workdir='build/cordova-plugman',haltOnFailure=True,description='Install Plugman',descriptionDone='Install Plugman'),
     ShellCommand(command=["npm","test"], workdir='build/cordova-plugman',haltOnFailure=True,description='Test Plugman',descriptionDone='Test Plugman'),
@@ -187,9 +181,9 @@ plugman_steps = [
 # The steps that are required for any platform just to get tools and source in place
 common_steps_1 = [
     ShellCommand(command=["rm","-rf","medic"],workdir='build',haltOnFailure=False,description='Medic Clean',descriptionDone='Medic Clean'),
-    ShellCommand(command=[shellCmd,shellRunParam,"rm -rf cordova-*"],workdir='build',haltOnFailure=False,description='Cordova Clean', descriptionDone='Cordova Clean'),
+    ShellCommand(command=["rm","-rf","cordova-*"],workdir='build',haltOnFailure=False,description='Cordova Clean', descriptionDone='Cordova Clean'),
     ShellCommand(command=["rm","-rf","mobilespec"],workdir='build',haltOnFailure=False,description='Mobilespec Clean',descriptionDone='Mobilespec Clean'),
-    ShellCommand(command=[shellCmd,shellRunParam,"git clone -b " + branches['TESTMASTER'] + " " + repos['TESTMASTER']+" medic"],workdir='build',haltOnFailure=True, description='Get Medic', descriptionDone='Get Medic'),
+    ShellCommand(command=["git","clone","-b",branches['TESTMASTER'],repos['TESTMASTER'],"medic"],workdir='build',haltOnFailure=True, description='Get Medic', descriptionDone='Get Medic'),
     # --production switch is used to speed up installation + fruitstrap dev dependency is not supported on Windows
     ShellCommand(command=["npm","install","--production"], workdir='build/medic',haltOnFailure=True,description='Install Medic',descriptionDone='Install Medic'),
     ShellCommand(command=["cp","../../../../config.json","./config.json"], workdir='build/medic',haltOnFailure=True,description='Copy Config',descriptionDone='Copy Config'),
@@ -200,8 +194,8 @@ common_steps_1 = [
 # The steps for any platform before platform add
 common_steps_mobilespec_1 = [
     ShellCommand(command=["mkdir","node_modules"],workdir='build/cordova-cli',haltOnFailure=True,description='prepare cordova-lib',descriptionDone='Prepare cordova-lib'),
-    ShellCommand(command=[shellCmd,shellRunParam, "git clone -b " + branches['CORDOVA-LIB']  + ' ' + repos['CORDOVA-LIB'] + " cordova-lib"],workdir='build',haltOnFailure=True,description='Update Cordova-lib',descriptionDone='Update Cordova-lib'),
-    ShellCommand(command=[shellCmd,shellRunParam,"ln -s ../../cordova-lib/cordova-lib cordova-lib"],workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
+    ShellCommand(command=["git","clone","-b",branches['CORDOVA-LIB'],repos['CORDOVA-LIB'],"cordova-lib"],workdir='build',haltOnFailure=True,description='Update Cordova-lib',descriptionDone='Update Cordova-lib'),
+    ShellCommand(command=["ln","-s","../../cordova-lib/cordova-lib","cordova-lib"],workdir='build/cordova-cli/node_modules',haltOnFailure=False,description='Cordova-lib link', descriptionDone='Cordova-lib link'),
     ShellCommand(command=["npm","install","--production"], workdir='build/cordova-cli/node_modules/cordova-lib',haltOnFailure=True,description='Install Cordova-lib',descriptionDone='Install Cordova-lib'),
     ShellCommand(command=["rm","-f", "npm-shrinkwrap.json"],workdir='build/cordova-cli',haltOnFailure=False,description='Remove CLI SW',descriptionDone='Remove CLI SW'),
     ShellCommand(command=["sed","-e","s/cordova-lib\": \"0./cordova-lib\": \">=0./","-i","bak","package.json"],workdir='build/cordova-cli',haltOnFailure=True,description='Edit json',descriptionDone='Edit json'),
@@ -212,7 +206,7 @@ common_steps_mobilespec_1 = [
 # The steps for any platform after platform add
 copy_www_cmd = ShellCommand(command=["ln","-s","../cordova-mobile-spec","www"],workdir='build/mobilespec',haltOnFailure=True,description ='Link www',descriptionDone ='Link www')
 if is_Windows :
-    copy_www_cmd=ShellCommand(command=["cp","-r","../cordova-mobile-spec","www"],workdir='build\\mobilespec',haltOnFailure=True,description ='Copy www',descriptionDone ='Copy www')
+    copy_www_cmd=ShellCommand(command=["cp","-r","../cordova-mobile-spec","www"],workdir='build/mobilespec',haltOnFailure=True,description ='Copy www',descriptionDone ='Copy www')
 common_steps_mobilespec_2 = [
     ShellCommand(command=["node", "../cordova-cli/bin/cordova","plugin","add","../cordova-mobile-spec/dependencies-plugin","--searchpath",".." ],workdir='build/mobilespec',haltOnFailure=True,description='Plugin add',descriptionDone='Plugin add'),
     ShellCommand(command=["node", "../cordova-cli/bin/cordova", "plugin", "add", "../medic/cordova-plugin-medic"],workdir='build/mobilespec',haltOnFailure=True,description='Medic plugin add',descriptionDone='Medic plugin add'),
@@ -241,9 +235,9 @@ c['builders'] = []
 
 if(build_ios) :
     factory_IOS_master = BuildFactory()
-    factory_IOS_master.addStep(ShellCommand(command=[shellCmd,shellRunParam,"rm -rf ~/.cordova/lib/ios"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
+    factory_IOS_master.addStep(ShellCommand(command=["rm","-rf","~/.cordova/lib/ios"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
     factory_IOS_master.addSteps(common_steps_1)
-    factory_IOS_master.addStep(ShellCommand(command=[shellCmd,shellRunParam,"./cordova-coho/coho repo-clone -r plugins -r mobile-spec -r ios -r cli -r js "],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
+    factory_IOS_master.addStep(ShellCommand(command=["./cordova-coho/coho","repo-clone","-r","plugins","-r","mobile-spec","-r","ios","-r","cli","-r","js"],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
     factory_IOS_master.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLUGIN","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Plugins->master',descriptionDone='Plugins->master'))
     factory_IOS_master.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLATFORM","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Platform->master',descriptionDone='Platform->master'))
     factory_IOS_master.addSteps(common_steps_mobilespec_1)
@@ -257,9 +251,9 @@ if(build_ios) :
 
 if(build_android) :
     factory_Android_master = BuildFactory()
-    factory_Android_master.addStep(ShellCommand(command=[shellCmd,shellRunParam,"rm -rf ~/.cordova/lib/android"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
+    factory_Android_master.addStep(ShellCommand(command=["rm","-rf","~/.cordova/lib/android"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
     factory_Android_master.addSteps(common_steps_1)
-    factory_Android_master.addStep(ShellCommand(command=[shellCmd,shellRunParam,"./cordova-coho/coho repo-clone -r plugins -r mobile-spec -r android -r cli -r js "],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
+    factory_Android_master.addStep(ShellCommand(command=["./cordova-coho/coho","repo-clone","-r","plugins","-r","mobile-spec","-r","android","-r","cli","-r","js"],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
     factory_Android_master.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLUGIN","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Plugins->master',descriptionDone='Plugins->master'))
     factory_Android_master.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLATFORM","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Platform->master',descriptionDone='Platform->master'))
 #   factory_Android_master.addStep(ShellCommand(command=[shellCmd,shellRunParam,'[ -f "package.json" ] && npm install'],workdir='build/cordova-android/bin',haltOnFailure=True,description='NPM Install', descriptionDone='NPM Install'))
@@ -274,18 +268,18 @@ if(build_android) :
 
 if(build_wp8) :
     factory_wp8 = BuildFactory()
-    factory_wp8.addStep(ShellCommand(command=[shellCmd,shellRunParam,"rm -rf %userprofile%/.cordova/lib/wp"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
+    factory_wp8.addStep(ShellCommand(command=["rm","-rf","%userprofile%/.cordova/lib/wp"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
     factory_wp8.addSteps(common_steps_1)
-    factory_wp8.addStep(ShellCommand(command=[shellCmd,shellRunParam,"node .\\cordova-coho\\coho repo-clone -r plugins -r mobile-spec -r wp8 -r js "],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
+    factory_wp8.addStep(ShellCommand(command=["node","./cordova-coho/coho","repo-clone","-r","plugins","-r","mobile-spec","-r","wp8","-r","js"],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
     # TODO find the way to specify cli branch to clone for COHO, currently use step below
-    factory_wp8.addStep(ShellCommand(command=[shellCmd,shellRunParam, "git clone -b " + branches['CLI'] + ' ' + repos['CLI'] + " cordova-cli"],workdir='build',haltOnFailure=True, description='Get CLI', descriptionDone='Get CLI'))
+    factory_wp8.addStep(ShellCommand(command=["git","clone","-b",branches['CLI'],repos['CLI'],"cordova-cli"],workdir='build',haltOnFailure=True, description='Get CLI', descriptionDone='Get CLI'))
     factory_wp8.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLUGIN","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Plugins->master',descriptionDone='Plugins->master'))
     factory_wp8.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLATFORM","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Platform->master',descriptionDone='Platform->master'))
     # pach cordova-wp8 template to prevent app to lock the screen. In other case we won't be able to re-install the app next time.
     factory_wp8.addStep(ShellCommand(command=["node","medic\src\utils\patch_wp8_template.js"],workdir='build',haltOnFailure=True, description='Patch WP8 template',descriptionDone='Patch WP8 template'))
     factory_wp8.addSteps(common_steps_mobilespec_1)
     factory_wp8.addStep(ShellCommand(command=["node","medic/writejson.js","--branch=master"],workdir='build',haltOnFailure=True, description='Write json',descriptionDone='Write json'))
-    factory_wp8.addStep(ShellCommand(command=["node","../cordova-cli/bin/cordova","platform","add","wp8"],workdir='build\\mobilespec',haltOnFailure=True, description='Platform Add',descriptionDone='Platform Add'))
+    factory_wp8.addStep(ShellCommand(command=["node","../cordova-cli/bin/cordova","platform","add","wp8"],workdir='build/mobilespec',haltOnFailure=True, description='Platform Add',descriptionDone='Platform Add'))
     factory_wp8.addSteps(common_steps_js)
     factory_wp8.addSteps(common_steps_mobilespec_2)
     factory_wp8.addStep(ShellCommand(command=["cp","-f","cordova-js/pkg/cordova.windowsphone.js","mobilespec/platforms/wp8/platform_www/cordova.js"],workdir='build',haltOnFailure=True,description='Copy JS',descriptionDone='Copy JS'))
@@ -295,16 +289,16 @@ if(build_wp8) :
 
 if(build_windows8) :
     factory_windows8 = BuildFactory()
-    factory_windows8.addStep(ShellCommand(command=[shellCmd,shellRunParam,"rm -rf %userprofile%/.cordova/lib/windows8"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
+    factory_windows8.addStep(ShellCommand(command=["rm","-rf","%userprofile%/.cordova/lib/windows8"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
     factory_windows8.addSteps(common_steps_1)
-    factory_windows8.addStep(ShellCommand(command=[shellCmd,shellRunParam,"node .\\cordova-coho\\coho repo-clone -r plugins -r mobile-spec -r windows -r js "],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
+    factory_windows8.addStep(ShellCommand(command=["node","./cordova-coho/coho","repo-clone","-r","plugins","-r","mobile-spec","-r","windows","-r","js"],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
     # TODO find the way to specify cli branch to clone for COHO, currently use step below
-    factory_windows8.addStep(ShellCommand(command=[shellCmd,shellRunParam, "git clone -b " + branches['CLI'] + ' ' + repos['CLI'] + " cordova-cli"],workdir='build',haltOnFailure=True, description='Get CLI', descriptionDone='Get CLI'))
+    factory_windows8.addStep(ShellCommand(command=["git","clone","-b",branches['CLI'],repos['CLI'],"cordova-cli"],workdir='build',haltOnFailure=True, description='Get CLI', descriptionDone='Get CLI'))
     factory_windows8.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLUGIN","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Plugins->master',descriptionDone='Plugins->master'))
     factory_windows8.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLATFORM","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Platform->master',descriptionDone='Platform->master'))
     factory_windows8.addSteps(common_steps_mobilespec_1)
     factory_windows8.addStep(ShellCommand(command=["node","medic/writejson.js","--branch=master"],workdir='build',haltOnFailure=True, description='Write json',descriptionDone='Write json'))
-    factory_windows8.addStep(ShellCommand(command=["node","../cordova-cli/bin/cordova","platform","add","windows8"],workdir='build\\mobilespec',haltOnFailure=True, description='Platform Add',descriptionDone='Platform Add'))
+    factory_windows8.addStep(ShellCommand(command=["node","../cordova-cli/bin/cordova","platform","add","windows8"],workdir='build/mobilespec',haltOnFailure=True, description='Platform Add',descriptionDone='Platform Add'))
     factory_windows8.addSteps(common_steps_js)
     factory_windows8.addSteps(common_steps_mobilespec_2)
     factory_windows8.addStep(ShellCommand(command=["cp","-f","cordova-js/pkg/cordova.windows8.js","mobilespec/platforms/windows8/platform_www/cordova.js"],workdir='build',haltOnFailure=True,description='Copy JS',descriptionDone='Copy JS'))
@@ -314,9 +308,9 @@ if(build_windows8) :
 
 if(build_blackberry) :
     factory_BlackBerry = BuildFactory()
-    factory_BlackBerry.addStep(ShellCommand(command=[shellCmd,shellRunParam,"rm -rf ~/.cordova/lib/blackberry10"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
+    factory_BlackBerry.addStep(ShellCommand(command=["rm","-rf","~/.cordova/lib/blackberry10"],workdir='build',haltOnFailure=False,description='Remove cache',descriptionDone='Remove cache'))
     factory_BlackBerry.addSteps(common_steps_1)
-    factory_BlackBerry.addStep(ShellCommand(command=[shellCmd,shellRunParam,"./cordova-coho/coho repo-clone -r plugins -r mobile-spec -r blackberry -r cli -r js "],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
+    factory_BlackBerry.addStep(ShellCommand(command=["./cordova-coho/coho","repo-clone","-r plugins","-r","mobile-spec","-r","blackberry","-r","cli","-r","js"],workdir='build',haltOnFailure=True,description='COHO Clone', descriptionDone='COHO Clone'))
     factory_BlackBerry.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLUGIN","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Plugins->dev',descriptionDone='Plugins->dev'))
     factory_BlackBerry.addStep(ShellCommand(command=["node","medic/checkout.js","--path=../../../repos.json","--cat=PLATFORM","--releasebranch="+branch_release],workdir='build',haltOnFailure=False,description='Platform->master',descriptionDone='Platform->master'))
     factory_BlackBerry.addSteps(common_steps_mobilespec_1)
@@ -344,7 +338,7 @@ if not is_Windows :
 if build_chrome :
     factory_chrome_desktop = BuildFactory()
     factory_chrome_desktop.addStep(ShellCommand(command=["rm","-rf","medic"],workdir='build',haltOnFailure=False,description='Medic Clean',descriptionDone='Medic Clean'))
-    factory_chrome_desktop.addStep(ShellCommand(command=[shellCmd,shellRunParam,"git clone -b " + branches['TESTMASTER'] + " " + repos['TESTMASTER']+" medic"],workdir='build',haltOnFailure=True, description='Get Medic', descriptionDone='Get Medic'))
+    factory_chrome_desktop.addStep(ShellCommand(command=["git","clone","-b",branches['TESTMASTER'],repos['TESTMASTER'],"medic"],workdir='build',haltOnFailure=True, description='Get Medic', descriptionDone='Get Medic'))
     # --production switch is used to speed up installation + fruitstrap dev dependency is not supported on Windows
     factory_chrome_desktop.addStep(ShellCommand(command=["npm","install","--production"], workdir='build/medic',haltOnFailure=True,description='Install Medic',descriptionDone='Install Medic'))
     factory_chrome_desktop.addStep(ShellCommand(command=["rm","-rf","mobile-chrome-apps"],workdir='build',haltOnFailure=True, description='Clean Chromespec',descriptionDone='Clean Chromespec'))
@@ -355,7 +349,7 @@ if build_chrome :
 
     factory_chrome_mobile = BuildFactory()
     factory_chrome_mobile.addStep(ShellCommand(command=["rm","-rf","medic"],workdir='build',haltOnFailure=False,description='Medic Clean',descriptionDone='Medic Clean'))
-    factory_chrome_mobile.addStep(ShellCommand(command=[shellCmd,shellRunParam,"git clone -b " + branches['TESTMASTER'] + " " + repos['TESTMASTER']+" medic"],workdir='build',haltOnFailure=True, description='Get Medic', descriptionDone='Get Medic'))
+    factory_chrome_mobile.addStep(ShellCommand(command=["git","clone","-b",branches['TESTMASTER'],repos['TESTMASTER'],"medic"],workdir='build',haltOnFailure=True, description='Get Medic', descriptionDone='Get Medic'))
     # --production switch is used to speed up installation + fruitstrap dev dependency is not supported on Windows
     factory_chrome_mobile.addStep(ShellCommand(command=["npm","install","--production"], workdir='build/medic',haltOnFailure=True,description='Install Medic',descriptionDone='Install Medic'))
     factory_chrome_mobile.addStep(ShellCommand(command=["npm","install"],workdir='build/medic/runner',haltOnFailure=True, description='Install Runner',descriptionDone='Install Runner'))


### PR DESCRIPTION
shellCmd and shellRunCmd defined in master.cfg depends on the OS of the master, so if you have a OS X master and Windows client (or vice versa) a lot of steps will fail.
For some steps, like in wp8 and windows8 sections, we know they'll always run on Windows so we could always use 'cmd'. But in common sections or for a platform like android, it needs to work on both.

Fix for [CB-6909](https://issues.apache.org/jira/browse/CB-6909)
