### PR TITLE
CB-6899 Fixes 'Could not adapt' exception while parsing master.cfg

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -204,14 +204,11 @@ common_steps_mobilespec_1 = [
 ]
 
 # The steps for any platform after platform add
-copy_www_cmd = ShellCommand(command=["node", "-e", "require('fs').symlinkSync('../cordova-mobile-spec/www','www','dir')"], workdir='build/mobilespec',haltOnFailure=True,description='Link www', descriptionDone='Link www'),
-if is_Windows :
-    copy_www_cmd=ShellCommand(command=["cp","-r","../cordova-mobile-spec/www","www"],workdir='build/mobilespec',haltOnFailure=True,description ='Copy www',descriptionDone ='Copy www')
 common_steps_mobilespec_2 = [
     ShellCommand(command=["node", "../cordova-cli/bin/cordova","plugin","add","../cordova-mobile-spec/dependencies-plugin","--searchpath",".." ],workdir='build/mobilespec',haltOnFailure=True,description='Plugin add',descriptionDone='Plugin add'),
     ShellCommand(command=["node", "../cordova-cli/bin/cordova", "plugin", "add", "../medic/cordova-plugin-medic"],workdir='build/mobilespec',haltOnFailure=True,description='Medic plugin add',descriptionDone='Medic plugin add'),
     ShellCommand(command=["rm","-rf","mobilespec/www"],workdir='build',haltOnFailure=False,description='Remove www',descriptionDone='Remove www'),
-    copy_www_cmd,
+    ShellCommand(command=["node", "-e", "require('fs').symlinkSync('../cordova-mobile-spec/www','www','dir')"], workdir='build/mobilespec',haltOnFailure=True,description='Link www', descriptionDone='Link www'),
     ShellCommand(command=["node", "../cordova-cli/bin/cordova","prepare"],workdir='build/mobilespec',haltOnFailure=True,description='CLI Prepare',descriptionDone='CLI Prepare')
 ]
 
@@ -220,7 +217,7 @@ common_steps_mobilespec_2M = [
     ShellCommand(command=["node", "../cordova-cli/bin/cordova","plugin","add","../cordova-mobile-spec/dependencies-plugin","--searchpath",".." ],workdir='build/mobilespec',haltOnFailure=True,description='Plugin add',descriptionDone='Plugin add'),
     ShellCommand(command=["node", "../cordova-cli/bin/cordova", "plugin", "add", "../medic/cordova-plugin-medic"],workdir='build/mobilespec',haltOnFailure=True,description='Medic plugin add',descriptionDone='Medic plugin add'),
     ShellCommand(command=["rm","-rf","mobilespec/www"],workdir='build',haltOnFailure=False,description='Remove www',descriptionDone='Remove www'),
-    copy_www_cmd,
+    ShellCommand(command=["node", "-e", "require('fs').symlinkSync('../cordova-mobile-spec/www','www','dir')"], workdir='build/mobilespec',haltOnFailure=True,description='Link www', descriptionDone='Link www'),
     ShellCommand(command=["cp","mobilespec/www/config.xml","mobilespec/config.xml"],workdir='build',haltOnFailure=False,description='Copy config',descriptionDone='Copy config'),
     ShellCommand(command=["node", "../cordova-cli/bin/cordova","prepare"],workdir='build/mobilespec',haltOnFailure=True,description='CLI Prepare',descriptionDone='CLI Prepare')
 ]


### PR DESCRIPTION
Fixes `error while parsing config file: ('Could not adapt', (<buildbot.steps.shell.ShellCommand object at 0x5415750>,), <InterfaceClass buildbot.interfaces.IBuildStepFactory>) (traceback in logfile)` error while parsing master.cfg introduced in commit https://github.com/MSOpenTech/cordova-medic/commit/628926883ba59fc941c696628276b55b9e590385
