### PR TITLE
CB-7987 Rename buildbot slaves for medic tests to more specific names

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -75,12 +75,12 @@ from buildbot.buildslave import BuildSlave
 from buildbot.changes import pb
 
 c['slaves'] = [
-    BuildSlave("ios-slave", "pass", max_builds=1),
-    BuildSlave("android-slave", "pass", max_builds=1),
-    BuildSlave("windows-slave", "pass", max_builds=2),
-    BuildSlave("win8-slave", "pass", max_builds=2),
-    BuildSlave("blackberry-slave", "pass", max_builds=1),
-    BuildSlave("common-slave", "pass", max_builds=3)
+    BuildSlave("cordova-ios-slave", "pass", max_builds=1),
+    BuildSlave("cordova-android-slave", "pass", max_builds=1),
+    BuildSlave("cordova-windows-slave", "pass", max_builds=2),
+    BuildSlave("cordova-win8-slave", "pass", max_builds=2),
+    BuildSlave("cordova-blackberry-slave", "pass", max_builds=1),
+    BuildSlave("cordova-common-slave", "pass", max_builds=3)
 ]
 
 # 'slavePortnum' defines the TCP port to listen on for connections from slaves.
@@ -353,44 +353,44 @@ class PlatformTest_Blackberry(PlatformTestBase):
 if(build_ios):
     factory_IOS_master = BuildFactory()
     factory_IOS_master.addSteps(PlatformTest_iOS().get_all_steps())
-    c['builders'].append(BuilderConfig(name="IOS", slavenames=["ios-slave"], factory=factory_IOS_master))
+    c['builders'].append(BuilderConfig(name="IOS", slavenames=["cordova-ios-slave"], factory=factory_IOS_master))
 
 if(build_android):
     factory_Android_master = BuildFactory()
     factory_Android_master.addSteps(PlatformTest_Android().get_all_steps())
-    c['builders'].append(BuilderConfig(name="Android", slavenames=["android-slave"], factory=factory_Android_master))
+    c['builders'].append(BuilderConfig(name="Android", slavenames=["cordova-android-slave"], factory=factory_Android_master))
 
     factory_Android_build_only = BuildFactory()
     factory_Android_build_only.addSteps(PlatformTest_Android().get_build_steps())
-    c['builders'].append(BuilderConfig(name="AndroidWin", slavenames=["windows-slave"], factory=factory_Android_build_only))
+    c['builders'].append(BuilderConfig(name="AndroidWin", slavenames=["cordova-windows-slave"], factory=factory_Android_build_only))
 
 if(build_wp8):
     factory_wp8 = BuildFactory()
     factory_wp8.addSteps(PlatformTest_WP8().get_all_steps())
-    c['builders'].append(BuilderConfig(name="WP8", slavenames=["windows-slave"], factory=factory_wp8))
-    c['builders'].append(BuilderConfig(name="WP8_vs2012_win8", slavenames=["win8-slave"], factory=factory_wp8))
+    c['builders'].append(BuilderConfig(name="WP8", slavenames=["cordova-windows-slave"], factory=factory_wp8))
+    c['builders'].append(BuilderConfig(name="WP8_vs2012_win8", slavenames=["cordova-win8-slave"], factory=factory_wp8))
 
 if(build_windows8):
     factory_windows8 = BuildFactory()
     factory_windows8.addSteps(PlatformTest_Windows8().get_all_steps())
-    c['builders'].append(BuilderConfig(name="Windows8", slavenames=["windows-slave"], factory=factory_windows8))
-    c['builders'].append(BuilderConfig(name="Windows8_vs2012_win8", slavenames=["win8-slave"], factory=factory_windows8))
+    c['builders'].append(BuilderConfig(name="Windows8", slavenames=["cordova-windows-slave"], factory=factory_windows8))
+    c['builders'].append(BuilderConfig(name="Windows8_vs2012_win8", slavenames=["cordova-win8-slave"], factory=factory_windows8))
 
 if(build_blackberry):
     factory_BlackBerry = BuildFactory()
     factory_BlackBerry.addSteps(PlatformTest_Blackberry().get_all_steps())
-    c['builders'].append(BuilderConfig(name="BlackBerry", slavenames=["blackberry-slave"], factory=factory_BlackBerry))
+    c['builders'].append(BuilderConfig(name="BlackBerry", slavenames=["cordova-blackberry-slave"], factory=factory_BlackBerry))
 
 # TODO. temporary disable separate cli and plugman tests on Windows
 if not platform.system() == "Windows" :
     factory_cli = BuildFactory()
     factory_cli.addStep(ShellCommand(command=["rm","-rf","cordova-*"],workdir='build',haltOnFailure=False,description='Cordova Clean'))
     factory_cli.addSteps(cli_steps)
-    c['builders'].append(BuilderConfig(name="Tools_CLI",slavenames=["common-slave"],factory=factory_cli))
+    c['builders'].append(BuilderConfig(name="Tools_CLI",slavenames=["cordova-common-slave"],factory=factory_cli))
 
 #    factory_plugman = BuildFactory()
 #    factory_plugman.addSteps(plugman_steps)
-#    c['builders'].append(BuilderConfig(name="Tools_Plugman",slavenames=["common-slave"],factory=factory_plugman))
+#    c['builders'].append(BuilderConfig(name="Tools_Plugman",slavenames=["cordova-common-slave"],factory=factory_plugman))
 
 if build_chrome:
     factory_chrome_desktop = BuildFactory()
@@ -402,7 +402,7 @@ if build_chrome:
     factory_chrome_desktop.addStep(ShellCommand(command=["git", "clone", repos['CCA']], workdir='build', haltOnFailure=True, description='Fetch Chromespec', descriptionDone='Fetch Chromespec'))
     factory_chrome_desktop.addStep(ShellCommand(command=["npm", "install"], workdir='build/medic/runner', haltOnFailure=True, description='Install Runner', descriptionDone='Install Runner'))
     factory_chrome_desktop.addStep(ShellCommand(command=["node", "medic/runner/testrunner.js", "--cmd=medic/runner/runchrome.sh", "--path=mobile-chrome-apps/chrome-cordova/chrome-apps-api-tests", "--args=mobile-chrome-apps/chrome-cordova/chrome-apps-api-tests"], workdir='build', haltOnFailure=True, description='Run Chrome', descriptionDone='Run Chrome'))
-    c['builders'].append(BuilderConfig(name="ZChrome_Desktop", slavenames=["common-slave"], factory=factory_chrome_desktop))
+    c['builders'].append(BuilderConfig(name="ZChrome_Desktop", slavenames=["cordova-common-slave"], factory=factory_chrome_desktop))
 
     factory_chrome_mobile = BuildFactory()
     factory_chrome_mobile.addStep(ShellCommand(command=["rm", "-rf", "medic"], workdir='build', haltOnFailure=False, description='Medic Clean', descriptionDone='Medic Clean'))
@@ -418,7 +418,7 @@ if build_chrome:
     factory_chrome_mobile.addStep(ShellCommand(command=["mobile-chrome-apps/src/cca.js", "create", "ccatest", "--copy-from", "mobile-chrome-apps/chrome-cordova/chrome-apps-api-tests"], workdir='build', haltOnFailure=True, description='cca create', descriptionDone='cca create'))
 
     factory_chrome_mobile.addStep(ShellCommand(command=["node", "../medic/runner/testrunner.js", "--ip=192.168.1.122", "--port=6800", "--cmd=../medic/runner/runcca.sh", "--path=www", "--args=android"], workdir='build/ccatest', timeout=300, haltOnFailure=True, description='Run Mobile', descriptionDone='Run Mobile'))
-    c['builders'].append(BuilderConfig(name="ZChrome_Mobile", slavenames=["android-slave"], factory=factory_chrome_mobile))
+    c['builders'].append(BuilderConfig(name="ZChrome_Mobile", slavenames=["cordova-android-slave"], factory=factory_chrome_mobile))
 
 
 ####### STATUS TARGETS


### PR DESCRIPTION
 Added "cordova-" prefix to all slave names.
https://issues.apache.org/jira/browse/CB-7987
