### PR TITLE
[INFRA-8588] Fixing build script bugs, with a focus on OS X.

### DIFF
--- a/cordova.conf
+++ b/cordova.conf
@@ -157,6 +157,7 @@ class PlatformTestBase(object):
             ShellCommand(command=["rm", "-f", "npm-shrinkwrap.json"], workdir='build/cordova-cli', haltOnFailure=False, description='Remove CLI SW'),
             ShellCommand(command=["npm", "install"], workdir='build/cordova-cli', haltOnFailure=True, description='Install CLI'),
             ShellCommand(command=["npm", "test"], workdir='build/cordova-cli', haltOnFailure=True, description='Test CLI'),
+            ShellCommand(command=["npm", "install"], workdir='build/cordova-js', haltOnFailure=True, description='Install JS'),
         ]
 
     def plugman_steps(self):
@@ -182,7 +183,7 @@ class PlatformTestBase(object):
             ShellCommand(command=["cordova-coho/coho", "npm-link"], workdir='build', haltOnFailure=True, description='COHO npm-link'),
             # add --skiplink for createmobilespec since
             # it requires cordova-plugman repo to be cloned
-            ShellCommand(command=["cordova-mobile-spec/createmobilespec/createmobilespec", "--" + platform, "mobilespec", "--debug", "--skiplink"], workdir='build', haltOnFailure=True, description='Run createmobilespec'),
+            ShellCommand(command=["node", "cordova-mobile-spec/createmobilespec/createmobilespec.js", "--" + platform, "mobilespec", "--debug", "--skiplink"], workdir='build', haltOnFailure=True, description='Run createmobilespec'),
             ShellCommand(command=["node", "medic/updateconfig.js", "--" + self.platform], workdir='build', haltOnFailure=True, description='Update config')
         ]
 


### PR DESCRIPTION
Adding install step for `cordova-js` and running `createmobilespec.js` directly with `node` instead of running it from command-line scripts.