### PR TITLE
Re-direct output of removing working directory task

### DIFF
--- a/cordova.conf
+++ b/cordova.conf
@@ -110,7 +110,7 @@ from buildbot.steps.transfer import FileDownload
 
 def RMCommand(path, **kwargs):
     js_script = "var s = require('shelljs'); console.log('removing {path}'); s.rm('-rf', '{path}');".format(path=path)
-    return ShellCommand(command=['node', '-e', js_script], **kwargs)
+    return ShellCommand(command='node -e "'+ js_script + '"> ../rm.txt 2>&1', logfiles = {"log": "../rm.txt"}, **kwargs)
 
 def InstallShellJS():
     return ShellCommand(command=["npm", "install", "shelljs"], workdir='build', haltOnFailure=True, description='Install shelljs')
@@ -186,7 +186,7 @@ class PlatformTestBase(object):
             # Re-directing node output to a file is a workaround for a node.js bug
             # on windows where a piped stream does not get flushed when process.exit is called.
             # https://github.com/joyent/node/issues/3584
-            ShellCommand(command="node cordova-mobile-spec/createmobilespec/createmobilespec.js --" + platform + " mobilespec --debug --skiplink >createmobilespecOut.txt 2>&1", 
+            ShellCommand(command="node cordova-mobile-spec/createmobilespec/createmobilespec.js --" + platform + " mobilespec --debug --skiplink >createmobilespecOut.txt 2>&1",
                 workdir='build', haltOnFailure=True, description='Run createmobilespec', logfiles = {"log" : "createmobilespecOut.txt"}),
             ShellCommand(command=["node", "medic/updateconfig.js", "--" + self.platform], workdir='build', haltOnFailure=True, description='Update config')
         ]


### PR DESCRIPTION
I had a bug in my previous commit for this that I had updated on my local git but forgot to push. The issue is that rm.txt is getting placed in working directory which is being cleaned and results in an issue.