### PR TITLE
[INFRA-8588] Improving Medic config robustness

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -38,8 +38,8 @@ from buildbot.buildslave import BuildSlave
 c['slaves'] = [
     BuildSlave("cordova-ios-slave", "pass", max_builds=1),
     BuildSlave("cordova-android-slave", "pass", max_builds=1),
-    BuildSlave("cordova-windows-slave", "pass", max_builds=2),
-    BuildSlave("cordova-win8-slave", "pass", max_builds=2),
+    BuildSlave("cordova-windows-slave", "pass", max_builds=1),
+    BuildSlave("cordova-win8-slave", "pass", max_builds=1),
     BuildSlave("cordova-blackberry-slave", "pass", max_builds=1),
     BuildSlave("cordova-common-slave", "pass", max_builds=3),
 ]
@@ -208,9 +208,9 @@ authz_cfg = authz.Authz(auth=auth.BasicAuth([("Cordova", "Cordova")]),
                         forceBuild=True,  # 'auth', # use this to test your slave once it is set up
                         forceAllBuilds=False,
                         pingBuilder=False,
-                        stopBuild=False,
+                        stopBuild='auth',
                         stopAllBuilds=False,
-                        cancelPendingBuild=False,
+                        cancelPendingBuild='auth',
                         )
 
 mail_from = str(json_config['mail']['from'])


### PR DESCRIPTION
Enabling build cancellation. Serializing builds to mitigate resource conflicts (like meulators, or npm).