### PR TITLE
[CB-8803] Reduce the effect of intermittent workspace cleanup failure

### DIFF
--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -229,6 +229,8 @@ plugins_cleanup_steps = [
     NPMInstall(command=['shelljs'], what='shelljs'),
     RMRF('~/.cordova/*', description='removing cache', haltOnFailure=False),
     RMRF(BASE_WORKDIR + '/*', description='cleaning workspace', haltOnFailure=False),
+    RMRF(BASE_WORKDIR + '/*', description='cleaning workspace again', haltOnFailure=False),
+    RMRF(BASE_WORKDIR + '/*', description='cleaning workspace yet again', haltOnFailure=True),
 ]
 
 common_plugins_steps = plugins_cleanup_steps + get_medic_steps + [


### PR DESCRIPTION
Really simple workaround for now. In the future a more complex wrapper should be made to persistently delete until the directory is gone, or emit a hard failure.