### PR TITLE
[CB-8853] Killing Android emulator before build.

### DIFF
--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -79,6 +79,11 @@ def running_tasks_on_platform(platform_name, os_name):
         return ['Xde.exe']
     elif platform_name == 'ios':
         return ['iOS Simulator']
+    elif platform_name == 'android':
+        if os_name == WINDOWS:
+            return ['emulator-arm.exe', 'adb.exe']
+        elif os_name == OSX:
+            return ['emulator64-x86']
     return []
 
 def can_find_running_tasks(step):


### PR DESCRIPTION
This works around the issue with the running emulator process preventing running builds. A full solution will come later with a deeper dive into the [Android build script](https://github.com/apache/cordova-medic/blob/master/src/build/makers/android.js).