### PR TITLE
[CB-8910] Fixing growing temp directory issue

### DIFF
--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -34,6 +34,8 @@ DEFAULT_REPO_NAME   = 'src'
 BASE_WORKDIR        = '.'
 TEST_APP_NAME       = 'mobilespec'
 REPOS_PROPERTY_NAME = 'repositories_config'
+NPM_CACHE_DIR       = 'npm_cache'
+NPM_TEMP_DIR        = 'npm_tmp'
 
 OSX     = 'osx'
 LINUX   = 'linux'
@@ -153,7 +155,11 @@ def NPMInstall(command=list(), **kwargs):
     # NOTE:
     #      adding the --cache parameter so that we don't use the global
     #      npm cache, which is shared with other processes
-    return NPM('install', command=command + [I('--cache=%(prop:workdir)s/npm_cache')], **kwargs)
+    #
+    #      adding the --tmp parameter so that even if the command doesn't
+    #      exit cleanly, the folder will get removed during cleanup;
+    #      refer to: https://docs.npmjs.com/files/folders#temp-files
+    return NPM('install', command=command + [I('--cache=%(prop:workdir)s/' + NPM_CACHE_DIR), I('--tmp=%(prop:workdir)s/' + NPM_TEMP_DIR)], **kwargs)
 
 def NPMTest(**kwargs):
     return NPM('test', **kwargs)


### PR DESCRIPTION
Specifying NPM temp folder to be in build directory instead of system temp folder so that it gets cleaned up during `medic.js clean`.