### PR TITLE
INFRA-9518 Remove IRC bot config

### DIFF
--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -282,23 +282,7 @@ c['builders'].extend([
 
 ####### STATUS TARGETS
 
-c['status'].extend([
-
-    # IRC bot
-    words.IRC(
-        host          = 'irc.freenode.net',
-        nick          = 'cordova-bot',
-        allowForce    = True,
-        channels      = ['#cordova'],
-        categories    = ['all'],
-        notify_events = {
-            'successToFailure': 1,
-            'failureToSuccess': 1,
-            'started':          0,
-            'finished':         1,
-        },
-    )
-])
+c['status'].extend([])
 
 ####### SCHEDULERS
 


### PR DESCRIPTION
Remove IRC bot from common medic config so we don't get a bot for every installation of medic. The actual IRC bot config will remain only in the SVN copy of `cordova.conf` that is used by Apache Infrastructure.