### PR TITLE
CB-8961 Killing more Android tasks on OSX

### DIFF
--- a/medic/medic-kill.js
+++ b/medic/medic-kill.js
@@ -41,7 +41,7 @@ function tasksOnPlatform(platformName) {
             if (util.isWindows()) {
                 return ["emulator-arm.exe", "adb.exe"];
             } else {
-                return ["emulator64-x86"];
+                return ["emulator64-x86", "emulator64-arm", "adb"];
             }
         case util.BLACKBERRY:
             return [];


### PR DESCRIPTION
Adding ARM emulator and ADB to list of killed tasks for Android on OSX.