### PR TITLE
CB-9011 Adding Buildbot feature support in medic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 node_modules
-cordova-config.json
-private.py
-cordova-extra.conf

--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ Then, install the Medic master configuration by copying the following files into
 - master.cfg
 - projects.conf
 - cordova.conf
-- cordova-extra.conf
 - cordova-repos.json
 - *cordova-config.json*<sup>[1]</sup>
+- *cordova-exta.conf*<sup>[1]</sup>
 - *private.py*<sup>[1]</sup>
+- *github.passwd*<sup>[1]</sup>
 
-<sup>[1]</sup> These two files do not exist in the repository and must be created for each installation of Medic. Create them from their respective `.sample` files.
+<sup>[1]</sup> These files do not exist in the repository and must be created for each installation of Medic. Create them from their respective `.sample` files.
 
 ## Slaves
 
@@ -161,6 +162,8 @@ In general, when any of the files in the master directory are changed, a restart
 **cordova-config.json**: Installation-specific file that defines miscellaneous parameters like CouchDB host and port, and email credentials. *Only a sample of this file is provided in the repo, with a `.sample` extension.*
 
 **private.py**: Python file containing sensitive configuration. *Only a sample of this file is provided in the repo, with a `.sample` extension.*
+
+**github.passwd**: File containing one line: a username and password for authenticating GitHub hooks. *Only a sample of this file is provided in the repo, with a `.sample` extension.*
 
 [couchdb]:          http://couchdb.apache.org/
 [python]:           https://www.python.org/downloads/

--- a/buildbot-conf/.gitignore
+++ b/buildbot-conf/.gitignore
@@ -1,0 +1,4 @@
+cordova-config.json
+private.py
+cordova-extra.conf
+github.passwd

--- a/buildbot-conf/cordova-repos.json
+++ b/buildbot-conf/cordova-repos.json
@@ -1,457 +1,285 @@
 {
     "mobile-chrome-apps": {
-        "codebase":  "chrome",
-        "codebases": {
-            "chrome": {
-                "repo":   "https://github.com/MobileChromeApps/mobile-chrome-apps.git",
-                "branch": "master"
-            }
+        "default_repository": "chrome",
+        "default_branch":     "master",
+        "repositories":       {
+            "chrome": "https://github.com/MobileChromeApps/mobile-chrome-apps.git"
         }
     },
 
     "cordova-medic": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-medic.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-medic.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-medic.git",
+            "github": "https://github.com/apache/cordova-medic.git"
         }
     },
     "cordova-coho": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-coho.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-coho.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-coho.git",
+            "github": "https://github.com/apache/cordova-coho.git"
         }
     },
     "cordova-mobile-spec": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-mobile-spec.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-mobile-spec.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-mobile-spec.git",
+            "github": "https://github.com/apache/cordova-mobile-spec.git"
         }
     },
 
     "cordova-cli": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-cli.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-cli.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-cli.git",
+            "github": "https://github.com/apache/cordova-cli.git"
         }
     },
     "cordova-plugman": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugman.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugman.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugman.git",
+            "github": "https://github.com/apache/cordova-plugman.git"
         }
     },
     "cordova-lib": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-lib.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-lib.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-lib.git",
+            "github": "https://github.com/apache/cordova-lib.git"
         }
     },
     "cordova-js": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-js.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-js.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-js.git",
+            "github": "https://github.com/apache/cordova-js.git"
         }
     },
 
     "cordova-android": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-android.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-android.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-android.git",
+            "github": "https://github.com/apache/cordova-android.git"
         }
     },
     "cordova-ios": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-ios.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-ios.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-ios.git",
+            "github": "https://github.com/apache/cordova-ios.git"
         }
     },
     "cordova-wp8": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-wp8.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-wp8.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-wp8.git",
+            "github": "https://github.com/apache/cordova-wp8.git"
         }
     },
     "cordova-windows": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-windows.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-windows.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-windows.git",
+            "github": "https://github.com/apache/cordova-windows.git"
         }
     },
     "cordova-blackberry": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-blackberry.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-blackberry.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-blackberry.git",
+            "github": "https://github.com/apache/cordova-blackberry.git"
         }
     },
 
     "cordova-plugin-test-framework": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-test-framework.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-test-framework.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-test-framework.git",
+            "github": "https://github.com/apache/cordova-plugin-test-framework.git"
         }
     },
     "cordova-plugins": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugins.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugins.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugins.git",
+            "github": "https://github.com/apache/cordova-plugins.git"
         }
     },
     "cordova-plugin-battery-status": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-battery-status.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-battery-status.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-battery-status.git",
+            "github": "https://github.com/apache/cordova-plugin-battery-status.git"
         }
     },
     "cordova-plugin-camera": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-camera.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-camera.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-camera.git",
+            "github": "https://github.com/apache/cordova-plugin-camera.git"
         }
     },
     "cordova-plugin-console": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-console.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-console.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-console.git",
+            "github": "https://github.com/apache/cordova-plugin-console.git"
         }
     },
     "cordova-plugin-contacts": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-contacts.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-contacts.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-contacts.git",
+            "github": "https://github.com/apache/cordova-plugin-contacts.git"
         }
     },
     "cordova-plugin-device": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-device.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git",
+            "github": "https://github.com/apache/cordova-plugin-device.git"
         }
     },
     "cordova-plugin-device-motion": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device-motion.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-device-motion.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device-motion.git",
+            "github": "https://github.com/apache/cordova-plugin-device-motion.git"
         }
     },
     "cordova-plugin-device-orientation": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device-orientation.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-device-orientation.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device-orientation.git",
+            "github": "https://github.com/apache/cordova-plugin-device-orientation.git"
         }
     },
     "cordova-plugin-dialogs": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-dialogs.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-dialogs.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-dialogs.git",
+            "github": "https://github.com/apache/cordova-plugin-dialogs.git"
         }
     },
     "cordova-plugin-file": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-file.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-file.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-file.git",
+            "github": "https://github.com/apache/cordova-plugin-file.git"
         }
     },
     "cordova-plugin-file-transfer": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-file-transfer.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-file-transfer.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-file-transfer.git",
+            "github": "https://github.com/apache/cordova-plugin-file-transfer.git"
         }
     },
     "cordova-plugin-geolocation": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-geolocation.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-geolocation.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-geolocation.git",
+            "github": "https://github.com/apache/cordova-plugin-geolocation.git"
         }
     },
     "cordova-plugin-globalization": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-globalization.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-globalization.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-globalization.git",
+            "github": "https://github.com/apache/cordova-plugin-globalization.git"
         }
     },
     "cordova-plugin-inappbrowser": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-inappbrowser.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-inappbrowser.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-inappbrowser.git",
+            "github": "https://github.com/apache/cordova-plugin-inappbrowser.git"
         }
     },
     "cordova-plugin-media": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-media.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-media.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-media.git",
+            "github": "https://github.com/apache/cordova-plugin-media.git"
         }
     },
     "cordova-plugin-media-capture": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-media-capture.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-media-capture.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-media-capture.git",
+            "github": "https://github.com/apache/cordova-plugin-media-capture.git"
         }
     },
     "cordova-plugin-network-information": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-network-information.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-network-information.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-network-information.git",
+            "github": "https://github.com/apache/cordova-plugin-network-information.git"
         }
     },
     "cordova-plugin-splashscreen": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-splashscreen.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-splashscreen.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-splashscreen.git",
+            "github": "https://github.com/apache/cordova-plugin-splashscreen.git"
         }
     },
     "cordova-plugin-statusbar": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-statusbar.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-statusbar.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-statusbar.git",
+            "github": "https://github.com/apache/cordova-plugin-statusbar.git"
         }
     },
     "cordova-plugin-vibration": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-vibration.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-vibration.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-vibration.git",
+            "github": "https://github.com/apache/cordova-plugin-vibration.git"
         }
     },
     "cordova-plugin-whitelist": {
-        "codebase":  "github",
-        "codebases": {
-            "asf":  {
-                "repo":   "https://git-wip-us.apache.org/repos/asf/cordova-plugin-whitelist.git",
-                "branch": "master"
-            },
-            "github":  {
-                "repo":   "https://github.com/apache/cordova-plugin-whitelist.git",
-                "branch": "master"
-            }
+        "default_repository": "github",
+        "default_branch":     "master",
+        "repositories":       {
+            "asf":    "https://git-wip-us.apache.org/repos/asf/cordova-plugin-whitelist.git",
+            "github": "https://github.com/apache/cordova-plugin-whitelist.git"
         }
     }
 }

--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -3,7 +3,9 @@ import re
 import json
 import socket
 
+from buildbot.scheduler import AnyBranchScheduler
 from buildbot.schedulers.timed import Nightly
+from buildbot.schedulers.forcesched import ForceScheduler
 
 from buildbot.process.factory import BuildFactory
 from buildbot.config import BuilderConfig
@@ -11,6 +13,8 @@ from buildbot.config import BuilderConfig
 from buildbot.process.properties import renderer
 from buildbot.process.properties import Interpolate as I
 from buildbot.process.properties import Property as P
+
+from buildbot.changes.filter import ChangeFilter
 
 from buildbot.steps.source.git import Git
 from buildbot.steps.transfer import FileDownload
@@ -20,22 +24,20 @@ from buildbot.steps.master import SetProperty
 from buildbot.status import words, results
 
 # config
-MEDIC_CONFIG_FILE    = os.path.join(FP, 'cordova-config.json')
-PROJECTS_CONFIG_FILE = os.path.join(FP, 'cordova-repos.json')
+MEDIC_CONFIG_FILE = os.path.join(FP, 'cordova-config.json')
+REPOS_CONFIG_FILE = os.path.join(FP, 'cordova-repos.json')
 
 def parse_config_file(file_name):
     with open(file_name, 'r') as config_file:
         return json.load(config_file)
 
-medic_config    = parse_config_file(MEDIC_CONFIG_FILE)
-projects_config = parse_config_file(PROJECTS_CONFIG_FILE)
+medic_config = parse_config_file(MEDIC_CONFIG_FILE)
+repos_config = parse_config_file(REPOS_CONFIG_FILE)
 
 # constants
-DEFAULT_REPO_NAME      = 'src'
 BASE_WORKDIR           = '.'
 TEST_APP_NAME          = 'mobilespec'
 EXTRA_CONFIG_FILE_NAME = 'cordova-extra.conf'
-REPOS_PROPERTY_NAME    = 'repositories_config'
 NPM_CACHE_DIR          = 'npm_cache'
 NPM_TEMP_DIR           = 'npm_tmp'
 COUCHDB_URI            = medic_config['couchdb']['uri']
@@ -47,12 +49,41 @@ MASTER_HOSTNAME        = socket.gethostname()
 CORDOVA_SUPPORTED_CATEGORY   = 'cordova'
 CORDOVA_UNSUPPORTED_CATEGORY = 'cordova-medic-unsupported'
 
-OSX     = 'osx'
-LINUX   = 'linux'
-WINDOWS = 'windows'
+CORE_PLUGINS = [
+    'cordova-plugins',
+    'cordova-plugin-test-framework',
+    'cordova-plugin-battery-status',
+    'cordova-plugin-camera',
+    'cordova-plugin-console',
+    'cordova-plugin-contacts',
+    'cordova-plugin-device',
+    'cordova-plugin-device-motion',
+    'cordova-plugin-device-orientation',
+    'cordova-plugin-dialogs',
+    'cordova-plugin-file',
+    'cordova-plugin-file-transfer',
+    'cordova-plugin-geolocation',
+    'cordova-plugin-globalization',
+    'cordova-plugin-inappbrowser',
+    'cordova-plugin-media',
+    'cordova-plugin-media-capture',
+    'cordova-plugin-network-information',
+    'cordova-plugin-splashscreen',
+    'cordova-plugin-statusbar',
+    'cordova-plugin-vibration',
+    'cordova-plugin-whitelist',
+]
+
+# NOTE:
+#      this is a special value that must be '' in order for
+#      all other non-Cordova builders on a master to work;
+#      more info is in the Buildbot documentation:
+#          http://docs.buildbot.net/0.8.10/manual/concepts.html#codebase
+#          http://docs.buildbot.net/0.8.10/manual/concepts.html#multiple-codebase-builds
+SPECIAL_DEFAULT_CODEBASE_NAME = ''
 
 # patterns
-CORDOVA_REPO_PATTERN = r'^.*(cordova-[^\.]+)\.git$'
+CORDOVA_REPO_PATTERN = r'.*(cordova-[^\.]+).*'
 
 ####### UTILITIES
 
@@ -73,45 +104,44 @@ class DisplayResults(Test):
         self.step_status.setText(self.describe(True))
 
 # helper functions
-def repo_name_from_url(url):
-    match = re.match(CORDOVA_REPO_PATTERN, url)
+def codebase_name_from_repo_uri(uri):
+    match = re.match(CORDOVA_REPO_PATTERN, uri)
     if match is not None:
         return match.group(1)
-    return DEFAULT_REPO_NAME
+    return SPECIAL_DEFAULT_CODEBASE_NAME
 
-def repo_codebase_from_name(name):
-    repo          = projects_config[name]
-    codebase_name = repo['codebase']
-    return repo['codebases'][codebase_name]
+def default_codebase_repo_uri(codebase_name):
+    codebase     = repos_config[codebase_name]
+    all_repos    = codebase['repositories']
+    default_repo = codebase['default_repository']
+    return all_repos[default_repo]
 
-def repo_url_from_name(name):
-    return repo_codebase_from_name(name)['repo']
-
-def repo_branch_from_name(name):
-    return repo_codebase_from_name(name)['branch']
+def default_codebase_branch(codebase_name):
+    return repos_config[codebase_name]['default_branch']
 
 def slugify(string):
-    return string.replace(' ', '-')
+    return string.lower().replace(' ', '-')
 
-def dont_use_default_repos(step):
-    return not use_default_repos(step)
+def make_codebase(codebase_name):
+    '''
+    Return a dict of default values for the given codebase.
+    '''
+    return {
+        'repository': default_codebase_repo_uri(codebase_name),
+        'branch':     default_codebase_branch(codebase_name),
+        'revision':   None,
+    }
 
-def use_default_repos(step):
-    return step.build.getProperty(REPOS_PROPERTY_NAME) is None
-
-# renderers
-@renderer
-def render_platform_repo_name(props):
-    platform_name = props.getProperty('platform')
-    repo_name     = 'cordova-{0}'.format(platform_name)
-    if platform_name == 'blackberry10':
+def get_platform_codebase(platform):
+    '''
+    Return the name of the codebase for the given platform.
+    This is almost always 'cordova-[PLATFORM]', except for
+    'blackberry', where it's 'blackberry10'.
+    '''
+    repo_name = 'cordova-{0}'.format(platform)
+    if platform == 'blackberry10':
         repo_name = 'cordova-blackberry'
     return repo_name
-
-@renderer
-def render_repo_name(props):
-    repo_url = props.getProperty('repository')
-    return repo_name_from_url(repo_url)
 
 # step wrappers
 def DescribedStep(step_class, description, haltOnFailure=True, **kwargs):
@@ -120,8 +150,8 @@ def DescribedStep(step_class, description, haltOnFailure=True, **kwargs):
 def SH(workdir=BASE_WORKDIR, timeout=TEST_RUN_TIMEOUT, **kwargs):
     return DescribedStep(ShellCommand, workdir=workdir, timeout=timeout, **kwargs)
 
-def NPM(npm_command, command=list(), what='code', **kwargs):
-    return SH(command=['npm', npm_command] + command, description='npm ' + npm_command + 'ing ' + what, **kwargs)
+def NPM(npm_subcommand, command=list(), what='code', **kwargs):
+    return SH(command=['npm', npm_subcommand] + command, description='npm ' + npm_subcommand + 'ing ' + what, **kwargs)
 
 def NPMInstall(command=list(), **kwargs):
     # NOTE:
@@ -136,23 +166,19 @@ def NPMInstall(command=list(), **kwargs):
 def NPMTest(**kwargs):
     return NPM('test', **kwargs)
 
-def BuildbotClone(repourl, what='code', workdir=None, **kwargs):
-    if workdir is None:
-        workdir = what
-    return DescribedStep(Git, 'cloning ' + what, repourl=repourl, workdir=workdir, mode='full', method='clobber', shallow=True, **kwargs)
+def Clone(repourl, hideStepIf=True, **kwargs):
+    return DescribedStep(Git, 'cloning', repourl=repourl, mode='full', method='clean', shallow=False, hideStepIf=hideStepIf, **kwargs)
 
-def CordovaClone(project_name, **kwargs):
-    branch   = repo_branch_from_name(project_name)
-    repo_url = repo_url_from_name(project_name)
-    return BuildbotClone(repourl=repo_url, branch=branch, what=project_name, **kwargs)
+def CodebaseClone(codebase, *args, **kwargs):
+    return Clone(repourl=I('%(src:' + codebase + ':repository)s'), codebase=codebase, workdir=codebase, **kwargs)
 
 def Set(name, value, **kwargs):
     return DescribedStep(SetProperty, 'setting ' + name, property=name, value=value, **kwargs)
 
 def Download(mastersrc, slavedest, description, **kwargs):
     # NOTE:
-    #      the FileDownload step has a bug and requires the
-    #      'description' parameter to be a list
+    #      the FileDownload step has a bug and requires
+    #      the 'description' parameter to be a list
     return FileDownload(mastersrc=mastersrc, slavedest=slavedest, description=[description], workdir=BASE_WORKDIR, **kwargs)
 
 ####### SLAVES
@@ -169,188 +195,278 @@ WINDOWS_SLAVES = ['cordova-windows-slave']
 # None, because Apache Buildbot's master.cfg manages them, and since
 # this file is shared with Apache Buildbot, we should not touch them.
 
+####### CODEBASES
+
+def cordovaCG(change_dict):
+    return codebase_name_from_repo_uri(change_dict['repository'])
+
+def overrideCG(existingCG):
+    def newCG(change):
+        codebase = cordovaCG(change)
+        if codebase == SPECIAL_DEFAULT_CODEBASE_NAME:
+            codebase = existingCG(change)
+        return codebase
+    return newCG
+
+# NOTE:
+#      codebaseGenerator is a magic function required by Buildbot
+#
+#      if a codebaseGenerator is already defined, we must only extend it;
+#      we choose to take precedence over the other implementation, only
+#      calling it if our own returns the SPECIAL_DEFAULT_CODEBASE_NAME codebase
+if 'codebaseGenerator' in c:
+    codebaseGenerator = overrideCG(c['codebaseGenerator'])
+else:
+    codebaseGenerator = cordovaCG
+
+c['codebaseGenerator'] = codebaseGenerator
+
+CORDOVA_CODEBASES = {codebase_name: make_codebase(codebase_name) for codebase_name in repos_config.keys()}
+
 ####### STEPS
 
-properties_steps = [
-    Set('repository_name',   render_repo_name),
+CORDOVA_STEPS_SET_SETTINGS = [
     Set('build_id',          I('%(prop:buildername)s-%(prop:buildnumber)s-' + MASTER_HOSTNAME)),
     Set('npm_cache_dir',     I('%(prop:builddir)s/' + NPM_CACHE_DIR)),
     Set('npm_temp_dir',      I('%(prop:builddir)s/' + NPM_TEMP_DIR)),
     Set('test_summary_file', I('%(prop:builddir)s/' + TEST_SUMMARY_FILE_NAME)),
 ]
 
-medic_steps = [
+CORDOVA_STEPS_CLEAN_UP = [
+    SH(command=['node', 'cordova-medic/medic/medic.js', 'clean', '--exclude', 'cordova-medic,' + NPM_CACHE_DIR], description='cleaning workspace'),
+]
 
-    # remove and re-clone medic
-    SH(command=['rm', '-rf', 'cordova-medic'], description='removing medic'),
-    CordovaClone('cordova-medic'),
+CORDOVA_STEPS_GET_MEDIC = [
 
-    # install medic
+    CodebaseClone('cordova-medic'),
+
     # NOTE:
     #      --production switch is used to speed up installation + fruitstrap dev dependency is not supported on Windows
     NPMInstall(command=['--production'], what='cordova-medic', workdir='cordova-medic'),
 ]
 
-cordova_plugins_prepare_steps = properties_steps + medic_steps + [
+CORDOVA_STEPS_GET_TOOLS = [
 
-    # kill emulators and clean workspace
-    SH(command=['node', 'cordova-medic/medic/medic.js', 'kill', '--platform', P('platform')], description='killing running tasks'),
-    SH(command=['node', 'cordova-medic/medic/medic.js', 'clean', '--exclude', 'cordova-medic,' + NPM_CACHE_DIR], description='cleaning workspace'),
+    CodebaseClone('cordova-coho'),
+    CodebaseClone('cordova-cli'),
+    CodebaseClone('cordova-lib'),
+    CodebaseClone('cordova-js'),
+    CodebaseClone('cordova-plugman'),
+    CodebaseClone('cordova-mobile-spec'),
 
-    # download medic's config to slave
-    Download(mastersrc=MEDIC_CONFIG_FILE, slavedest='cordova-medic/config.json', description='downloading master\'s config'),
-
-    # download repo config
-    # NOTE:
-    #      only one of these steps should be executed; thanks
-    #      to Buildbot there is no good if-else construct for
-    #      builds, so we have two steps with 'doStepIf's
-    SH(command=['curl', P(REPOS_PROPERTY_NAME), '--output', 'cordova-medic/cordova-repos.json'], description='downloading custom repo config', doStepIf=dont_use_default_repos),
-    Download(mastersrc=PROJECTS_CONFIG_FILE, slavedest='cordova-medic/cordova-repos.json', description='downloading default repo config', doStepIf=use_default_repos),
-
-    # clone all repos
-    # NOTE:
-    #      medic is excluded because it's already cloned
-    SH(command=['node', 'cordova-medic/medic/medic.js', 'checkout', '--config', 'cordova-medic/cordova-repos.json', '--exclude', 'cordova-medic'], description='cloning repositories'),
-
-    # install tools
     NPMInstall(what='cordova-coho',        workdir='cordova-coho'),
-    NPMInstall(what='cordova-lib',         workdir='cordova-lib/cordova-lib'),
     NPMInstall(what='cordova-cli',         workdir='cordova-cli'),
+    NPMInstall(what='cordova-lib',         workdir='cordova-lib/cordova-lib'),
     NPMInstall(what='cordova-js',          workdir='cordova-js'),
     NPMInstall(what='cordova-plugman',     workdir='cordova-plugman'),
-    NPMInstall(what='platform',            workdir=render_platform_repo_name),
     NPMInstall(what='cordova-mobile-spec', workdir='cordova-mobile-spec/createmobilespec'),
 
-    # link the installed code
     SH(command=['cordova-coho/coho', 'npm-link'], description='coho link'),
-
-    # prepare the test app
-    SH(
-        command = [
-            'node',
-            'cordova-mobile-spec/createmobilespec/createmobilespec.js',
-            '--copywww',
-            '--skiplink',
-            I('--%(prop:platform)s'),
-            TEST_APP_NAME
-        ],
-        description='creating mobilespec app'
-    ),
 ]
 
-cordova_plugins_run_command = [
-    'node',
-    'cordova-medic/medic/medic.js',
-    'run',
-    '--id',       P('build_id'),
-    '--platform', P('platform'),
-    '--couchdb',  COUCHDB_URI,
-    '--entry',    ENTRY_POINT,
-    '--app',      TEST_APP_NAME,
+def cordova_steps_get_plugins(plugins):
+    steps = []
+    for plugin in plugins:
+        steps.append(CodebaseClone(plugin))
+    return steps
 
-    # NOTE:
-    #      this timeout is smaller because TEST_RUN_TIMEOUT is used as the
-    #      buildbot timeout, and the "run" command needs to time out before
-    #      the buildbot wrapper times out so it can exit cleanly on timeout
-    '--timeout',  TEST_RUN_TIMEOUT - 60
-]
+def cordova_steps_create_mobilespec(platform):
+    return [
 
-cordova_plugins_check_command = [
-    'node',
-    'cordova-medic/medic/medic.js',
-    'check',
-    '--id',      P('build_id'),
-    '--couchdb', COUCHDB_URI,
-    '--file',    P('test_summary_file'),
-]
+        # get and install platform
+        CodebaseClone(get_platform_codebase(platform)),
+        NPMInstall(what='platform', workdir=get_platform_codebase(platform)),
 
-cordova_plugins_log_command = [
-    'node',
-    'cordova-medic/medic/medic.js',
-    'log',
-    '--platform', P('platform')
-]
+        # create mobilespec
+        SH(
+            command = [
+                'node',
+                'cordova-mobile-spec/createmobilespec/createmobilespec.js',
+                '--copywww',
+                '--skiplink',
+                '--' + platform,
+                TEST_APP_NAME
+            ],
+            description='creating mobilespec app'
+        ),
+    ]
 
-cordova_plugins_run_steps = [
-    SH(command=cordova_plugins_run_command, description='running tests'),
-    SH(command=cordova_plugins_log_command, description='gathering logs'),
-    SH(command=cordova_plugins_check_command, description='getting test results'),
-    SetPropertyFromCommand(command=['cat', P('test_summary_file')], property='test_summary', hideStepIf=True),
-    DisplayResults(warnOnWarnings=True),
-]
+def cordova_steps_run_tests(platform, extra_args=list()):
+    return [
 
-# NOTE:
-#      all of these have haltOnFailure=False because all the
-#      windows builds must run even if the previous ones failed
-cordova_plugins_windows_run_steps = [
+        # download medic's config to slave
+        Download(mastersrc=MEDIC_CONFIG_FILE, slavedest='cordova-medic/config.json', description='downloading master\'s config'),
 
-    SH(command=cordova_plugins_run_command + ['--winvers',  'store80'], description='running tests (Windows 8.0)', haltOnFailure=False),
-    SH(command=cordova_plugins_log_command, description='gathering logs'),
-    SH(command=cordova_plugins_check_command, description='getting test results (Windows 8.0)', haltOnFailure=False),
-    SetPropertyFromCommand(command=['cat', P('test_summary_file')], property='test_summary', hideStepIf=True, haltOnFailure=False),
-    DisplayResults(haltOnFailure=False, warnOnWarnings=True),
+        SH(
+            command=[
+                'node',
+                'cordova-medic/medic/medic.js',
+                'run',
+                '--id',       P('build_id'),
+                '--platform', platform,
+                '--couchdb',  COUCHDB_URI,
+                '--entry',    ENTRY_POINT,
+                '--app',      TEST_APP_NAME,
 
-    SH(command=cordova_plugins_run_command + ['--winvers',  'store'], description='running tests (Windows 8.1)', haltOnFailure=False),
-    SH(command=cordova_plugins_log_command, description='gathering logs'),
-    SH(command=cordova_plugins_check_command, description='getting test results (Windows 8.1)', haltOnFailure=False),
-    SetPropertyFromCommand(command=['cat', P('test_summary_file')], property='test_summary', hideStepIf=True, haltOnFailure=False),
-    DisplayResults(haltOnFailure=False, warnOnWarnings=True),
+                # NOTE:
+                #      this timeout is smaller because TEST_RUN_TIMEOUT is used as the
+                #      buildbot timeout, and the "run" command needs to time out before
+                #      the buildbot wrapper times out so it can exit cleanly on timeout
+                '--timeout',  TEST_RUN_TIMEOUT - 60
+            ] + extra_args,
+            description='running tests'
+        ),
 
-    SH(command=cordova_plugins_run_command + ['--winvers',  'phone'], description='running tests (Windows Phone 8.1)', haltOnFailure=False),
-    SH(command=cordova_plugins_log_command, description='gathering logs'),
-    SH(command=cordova_plugins_check_command, description='getting test results (Windows Phone 8.1)', haltOnFailure=False),
-    SetPropertyFromCommand(command=['cat', P('test_summary_file')], property='test_summary', hideStepIf=True, haltOnFailure=False),
-    DisplayResults(haltOnFailure=False, warnOnWarnings=True),
-]
+        SH(
+            command=[
+                'node',
+                'cordova-medic/medic/medic.js',
+                'check',
+                '--id',      P('build_id'),
+                '--couchdb', COUCHDB_URI,
+                '--file',    P('test_summary_file'),
+            ],
+            description='getting test results'
+        ),
 
-cordova_plugins_all = BuildFactory()
-cordova_plugins_all.addSteps(cordova_plugins_prepare_steps)
-cordova_plugins_all.addSteps(cordova_plugins_run_steps)
+        SH(
+            command=[
+                'node',
+                'cordova-medic/medic/medic.js',
+                'log',
+                '--platform', platform
+            ],
+            description='gathering logs'
+        ),
 
-# WORKAROUND:
-#            this is here to match what medic already does; these
-#            should be their own builders in the future, using a
-#            proper test matrix
-cordova_plugins_windows = BuildFactory()
-cordova_plugins_windows.addSteps(cordova_plugins_prepare_steps)
-cordova_plugins_windows.addSteps(cordova_plugins_windows_run_steps)
+        SetPropertyFromCommand(command=['cat', P('test_summary_file')], property='test_summary', hideStepIf=True),
+        DisplayResults(warnOnWarnings=True),
+    ]
+
+def makeRunSteps(platform, extra_args=list()):
+
+    factory = BuildFactory()
+
+    factory.addSteps(CORDOVA_STEPS_SET_SETTINGS)
+    factory.addSteps(CORDOVA_STEPS_GET_MEDIC)
+    factory.addSteps([
+        SH(command=['node', 'cordova-medic/medic/medic.js', 'kill', '--platform', platform], description='killing running tasks'),
+    ])
+    factory.addSteps(CORDOVA_STEPS_CLEAN_UP)
+    factory.addSteps(CORDOVA_STEPS_GET_TOOLS)
+
+    factory.addSteps(cordova_steps_get_plugins(CORE_PLUGINS))
+    factory.addSteps(cordova_steps_create_mobilespec(platform))
+    factory.addSteps(cordova_steps_run_tests(platform, extra_args=extra_args))
+
+    return factory
 
 ####### BUILDERS
 
+cordova_run_android = makeRunSteps('android')
+cordova_run_ios     = makeRunSteps('ios')
+cordova_run_ws80    = makeRunSteps('windows', extra_args=['--winvers', 'store80'])
+cordova_run_ws81    = makeRunSteps('windows', extra_args=['--winvers', 'store'])
+cordova_run_wp81    = makeRunSteps('windows', extra_args=['--winvers', 'phone'])
+cordova_run_wp8     = makeRunSteps('wp8')
+cordova_run_bbry    = makeRunSteps('blackberry10')
+
 c['builders'].extend([
 
-    BuilderConfig(name='cordova-ios',            slavenames=OSX_SLAVES,     factory=cordova_plugins_all,     category=CORDOVA_SUPPORTED_CATEGORY,   properties={'platform': 'ios'}),
-    BuilderConfig(name='cordova-android-osx',    slavenames=OSX_SLAVES,     factory=cordova_plugins_all,     category=CORDOVA_SUPPORTED_CATEGORY,   properties={'platform': 'android'}),
-    BuilderConfig(name='cordova-windows',        slavenames=WINDOWS_SLAVES, factory=cordova_plugins_windows, category=CORDOVA_SUPPORTED_CATEGORY,   properties={'platform': 'windows'}),
-    BuilderConfig(name='cordova-wp8',            slavenames=WINDOWS_SLAVES, factory=cordova_plugins_all,     category=CORDOVA_SUPPORTED_CATEGORY,   properties={'platform': 'wp8'}),
-    BuilderConfig(name='cordova-android-win',    slavenames=WINDOWS_SLAVES, factory=cordova_plugins_all,     category=CORDOVA_SUPPORTED_CATEGORY,   properties={'platform': 'android'}),
+    BuilderConfig(name='cordova-android-osx',      slavenames=OSX_SLAVES,     factory=cordova_run_android, category=CORDOVA_SUPPORTED_CATEGORY),
+    BuilderConfig(name='cordova-android-win',      slavenames=WINDOWS_SLAVES, factory=cordova_run_android, category=CORDOVA_SUPPORTED_CATEGORY),
+    BuilderConfig(name='cordova-ios',              slavenames=OSX_SLAVES,     factory=cordova_run_ios,     category=CORDOVA_SUPPORTED_CATEGORY),
+    BuilderConfig(name='cordova-windows-store8.0', slavenames=WINDOWS_SLAVES, factory=cordova_run_ws80,    category=CORDOVA_SUPPORTED_CATEGORY),
+    BuilderConfig(name='cordova-windows-store8.1', slavenames=WINDOWS_SLAVES, factory=cordova_run_ws81,    category=CORDOVA_SUPPORTED_CATEGORY),
+    BuilderConfig(name='cordova-windows-phone8.1', slavenames=WINDOWS_SLAVES, factory=cordova_run_wp81,    category=CORDOVA_SUPPORTED_CATEGORY),
+    BuilderConfig(name='cordova-wp8',              slavenames=WINDOWS_SLAVES, factory=cordova_run_wp8,     category=CORDOVA_SUPPORTED_CATEGORY),
 
-    BuilderConfig(name='cordova-blackberry-osx', slavenames=OSX_SLAVES,     factory=cordova_plugins_all,     category=CORDOVA_UNSUPPORTED_CATEGORY, properties={'platform': 'blackberry10'}),
-    BuilderConfig(name='cordova-blackberry-win', slavenames=WINDOWS_SLAVES, factory=cordova_plugins_all,     category=CORDOVA_UNSUPPORTED_CATEGORY, properties={'platform': 'blackberry10'}),
+    BuilderConfig(name='cordova-blackberry-win',   slavenames=WINDOWS_SLAVES, factory=cordova_run_bbry,    category=CORDOVA_UNSUPPORTED_CATEGORY),
+    BuilderConfig(name='cordova-blackberry-osx',   slavenames=OSX_SLAVES,     factory=cordova_run_bbry,    category=CORDOVA_UNSUPPORTED_CATEGORY),
 ])
 
 ####### STATUS TARGETS
 
 c['status'].extend([])
 
+####### CHANGE FILTERS
+
+cordova_e2e_run_triggers = ChangeFilter(codebase=CORE_PLUGINS + [
+    'cordova-cli',
+    'cordova-js',
+    'cordova-lib',
+    'cordova-plugman',
+    'cordova-mobile-spec',
+    'cordova-medic',
+    'cordova-windows',
+    'cordova-android',
+    'cordova-ios',
+    'cordova-blackberry',
+])
+
 ####### SCHEDULERS
 
 c['schedulers'].extend([
+
     Nightly(
-        name         = 'cordova_plugins_periodic',
-        reason       = 'periodic',
-        branch       = None,
-        minute       = [30],
-        hour         = range(0, 24, 2),
-        builderNames = [
-            'cordova-ios',
+        name          = 'cordova-e2e-periodic',
+        reason        = 'periodic',
+        codebases     = CORDOVA_CODEBASES,
+        branch        = None, # None means default branch
+        onlyIfChanged = True,
+
+        minute        = [30],
+        hour          = range(0, 24, 3),
+
+        builderNames  = [
             'cordova-android-osx',
-            'cordova-blackberry-osx',
-            'cordova-windows',
-            'cordova-wp8',
             'cordova-android-win',
+            'cordova-ios',
+            'cordova-windows-store8.0',
+            'cordova-windows-store8.1',
+            'cordova-windows-phone8.1',
+            'cordova-wp8',
             'cordova-blackberry-win',
+            'cordova-blackberry-osx',
+        ],
+    ),
+
+    AnyBranchScheduler(
+        name          = 'cordova-e2e-commit',
+        reason        = 'commit',
+
+        # NOTE:
+        #      in addition to 'change_filter', the 'codebases' argument ALSO functions
+        #      as a filter, and codebases not present in it will not trigger the scheduler
+        change_filter = cordova_e2e_run_triggers,
+        codebases     = CORDOVA_CODEBASES,
+
+        builderNames  = [
+            'cordova-android-osx',
+            'cordova-android-win',
+            'cordova-ios',
+            'cordova-windows-store8.0',
+            'cordova-windows-store8.1',
+            'cordova-windows-phone8.1',
+            'cordova-wp8',
+            'cordova-blackberry-win',
+            'cordova-blackberry-osx',
+        ],
+    ),
+
+    ForceScheduler(
+        name         = 'cordova-e2e-force',
+        codebases    = CORDOVA_CODEBASES,
+        builderNames = [
+            'cordova-android-osx',
+            'cordova-android-win',
+            'cordova-ios',
+            'cordova-windows-store8.0',
+            'cordova-windows-store8.1',
+            'cordova-windows-phone8.1',
+            'cordova-wp8',
+            'cordova-blackberry-win',
+            'cordova-blackberry-osx',
         ],
     ),
 ])

--- a/buildbot-conf/github.passwd.sample
+++ b/buildbot-conf/github.passwd.sample
@@ -1,0 +1,1 @@
+user:password

--- a/buildbot-conf/master.cfg
+++ b/buildbot-conf/master.cfg
@@ -277,7 +277,12 @@ mn1 = MailNotifier(
     smtpPassword          = mail_pw,
 )
 
-c['status'].append(html.WebStatus(http_port=8010, authz=authz_cfg))
+c['status'].append(html.WebStatus(
+    http_port            = 8010,
+    authz                = authz_cfg,
+    change_hook_dialects = {'github': True},
+    change_hook_auth     = ['file:github.passwd'],
+))
 c['status'].append(mn1)
 
 # Include any global imports here that more than one project needs.


### PR DESCRIPTION
Following are notable changes.

- Added commit-triggered builds.
- Now using Buildbot Codebases for each codebase; no more downloading repo configs.
- Made code more modular and less repetitive.
- Added GitHub hook support for test installations of Medic (the Apache Infrastructure installation of Medic has a different `master.conf`).
- Periodic builds no longer run if no changes are present.