### PR TITLE
CB-9196 Medic cleanup

### DIFF
--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -38,8 +38,8 @@ repos_config = parse_config_file(REPOS_CONFIG_FILE)
 BASE_WORKDIR           = '.'
 TEST_APP_NAME          = 'mobilespec'
 EXTRA_CONFIG_FILE_NAME = 'cordova-extra.conf'
-NPM_CACHE_DIR          = 'npm_cache'
-NPM_TEMP_DIR           = 'npm_tmp'
+NPM_CACHE_DIR_NAME     = 'npm_cache'
+NPM_TEMP_DIR_NAME      = 'npm_tmp'
 COUCHDB_URI            = medic_config['couchdb']['uri']
 ENTRY_POINT            = medic_config['app']['entry']
 TEST_RUN_TIMEOUT       = medic_config['app']['timeout'] # in seconds
@@ -240,13 +240,13 @@ CORDOVA_STEPS_SET_SETTINGS = [
     Set('build_id',          I('%(prop:buildername)s-%(prop:buildnumber)s-' + MASTER_HOSTNAME)),
     Set('test_summary_file', I('%(prop:builddir)s/' + TEST_SUMMARY_FILE_NAME)),
 
-    Set('npm_cache_dir',  I('%(prop:builddir)s/' + NPM_CACHE_DIR)),
-    Set('npm_temp_dir',   I('%(prop:builddir)s/' + NPM_TEMP_DIR)),
+    Set('npm_cache_dir',  I('%(prop:builddir)s/' + NPM_CACHE_DIR_NAME)),
+    Set('npm_temp_dir',   I('%(prop:builddir)s/' + NPM_TEMP_DIR_NAME)),
     Set('npm_prefix_dir', I('%(prop:builddir)s/')),
 ]
 
 CORDOVA_STEPS_CLEAN_UP = [
-    SH(command=['node', 'cordova-medic/medic/medic.js', 'clean', '--exclude', 'cordova-medic,' + NPM_CACHE_DIR], description='cleaning workspace'),
+    SH(command=['node', 'cordova-medic/medic/medic.js', 'clean', '.', '--exclude', 'cordova-medic', '--exclude', NPM_CACHE_DIR_NAME], description='cleaning workspace'),
 ]
 
 CORDOVA_STEPS_GET_MEDIC = [
@@ -367,7 +367,8 @@ def cordova_steps_run_tests(platform, extra_args=list()):
                 '--couchdb', COUCHDB_URI,
                 '--file',    P('test_summary_file'),
             ],
-            description = 'getting test results'
+            description   = 'getting test results',
+            haltOnFailure = True,
         ),
 
         SetPropertyFromCommand(command=['cat', P('test_summary_file')], property='test_summary', hideStepIf=True),

--- a/lib/testcheck.js
+++ b/lib/testcheck.js
@@ -23,24 +23,24 @@
 
 module.exports = function (sha, dbHost) {
 
-    var http = require('http'),
-        url = require('url'),
-        q = require('q');
+    var http = require("http"),
+        url = require("url"),
+        q = require("q");
 
     function getDocumentIdBySha() {
         var options = {
             host : url.parse(dbHost).hostname,
             port : url.parse(dbHost).port,
-            path : '/mobilespec_results/_all_docs?start_key="' + sha + '"&end_key="' + sha + '~"&limit=1'
+            path : "/mobilespec_results/_all_docs?start_key=\"" + sha + "\"&end_key=\"" + sha + "~\"&limit=1"
         },
-            resultsDoc = '',
+            resultsDoc = "",
             d = q.defer();
 
         http.get(options, function (result) {
             result.on("data", function (chunk) {
                 resultsDoc += chunk.toString();
             });
-            result.on('end', function () {
+            result.on("end", function () {
                 var parsedResult = JSON.parse(resultsDoc);
                 if (parsedResult.rows && parsedResult.rows.length > 0) {
                     d.resolve(parsedResult.rows[0].id);
@@ -48,19 +48,19 @@ module.exports = function (sha, dbHost) {
                     d.reject("There are no results for current test run in DB.");
                 }
             });
-        }).on('error', function (e) {
+        }).on("error", function (e) {
             console.log("Got error: " + e.message);
             d.reject(e);
         });
 
         return d.promise;
-    };
+    }
 
     function getTestResult(resultId) {
         var options = {
             host : url.parse(dbHost).hostname,
             port : url.parse(dbHost).port,
-            path : '/mobilespec_results/' + resultId
+            path : "/mobilespec_results/" + resultId
         };
         var d = q.defer();
         var resultsJSON = "";
@@ -69,16 +69,16 @@ module.exports = function (sha, dbHost) {
             res.on("data", function (chunk) {
                 resultsJSON += chunk;
             });
-            res.on('end', function () {
+            res.on("end", function () {
                 d.resolve(JSON.parse(resultsJSON));
             });
-        }).on('error', function (e) {
+        }).on("error", function (e) {
             console.log("Got error: " + e.message);
             d.reject(e);
         });
 
         return d.promise;
-    };
+    }
 
     return getDocumentIdBySha().then(getTestResult);
 };

--- a/lib/testwait.js
+++ b/lib/testwait.js
@@ -19,10 +19,10 @@
 
 /* jshint node: true */
 
-var shell = require('shelljs');
-var q     = require('q');
+var shell = require("shelljs");
+var q     = require("q");
 
-var couchdb = require('./couchdb');
+var couchdb = require("./couchdb");
 
 var mobilespec_results = null;
 
@@ -32,11 +32,11 @@ function init(uri) {
 }
 
 function query_for_sha(sha, callback) {
-    var view = 'sha?key="' + sha + '"';
+    var view = "sha?key=\"" + sha + "\"";
     // get build errors from couch for each repo
-    mobilespec_results.query_view('results', view, function(error, result) {
+    mobilespec_results.query_view("results", view, function(error, result) {
         if (error) {
-            console.error('query failed for mobilespec_results', error);
+            console.error("query failed for mobilespec_results", error);
             callback(true, error);
             return;
         }
@@ -45,25 +45,29 @@ function query_for_sha(sha, callback) {
 }
 
 function isTestsCompleted(sha, callback) {
-    query_for_sha(sha, function(isFailed, res) {
+    query_for_sha(sha, function (isFailed, res) {
         // return True if there is no error and there are test results in db for specified sha
         callback(!isFailed && res.rows.length > 0);
     });
 }
 
 function waitTestsCompleted(sha, timeoutMs) {
-   var defer = q.defer();
-   var startTime = Date.now(),
-       timeoutTime = startTime + timeoutMs,
-       checkInterval = 10 * 1000; // 10 secs
 
-    var testFinishedFn = setInterval(function(){
+    var defer          = q.defer();
+    var startTime      = Date.now();
+    var timeoutTime    = startTime + timeoutMs;
+    var checkInterval  = 10 * 1000; // 10 secs
 
-        isTestsCompleted(sha, function(isSuccess) {
+    var testFinishedFn = setInterval(function () {
+        isTestsCompleted(sha, function (isSuccess) {
             // if tests are finished or timeout
             if (isSuccess || Date.now() > timeoutTime) {
                 clearInterval(testFinishedFn);
-                isSuccess ? defer.resolve() : defer.reject('timed out');
+                if (isSuccess) {
+                    defer.resolve();
+                } else {
+                    defer.reject("timed out");
+                }
             }
         });
     }, checkInterval);
@@ -73,4 +77,4 @@ function waitTestsCompleted(sha, timeoutMs) {
 module.exports = {
     init:               init,
     waitTestsCompleted: waitTestsCompleted,
-}
+};

--- a/medic/.jshintrc
+++ b/medic/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "node": true,
+  "bitwise": true,
+  "undef": true,
+  "trailing": true,
+  "quotmark": true,
+  "indent": 4,
+  "unused": "vars",
+  "latedef": "nofunc",
+  "-W030": false
+}

--- a/medic/medic-check.js
+++ b/medic/medic-check.js
@@ -49,7 +49,7 @@ function main() {
     var couchdbURI = argv.couchdb;
     var outputPath = argv.file;
 
-    console.log('Getting test results for ' + buildId);
+    console.log("Getting test results for " + buildId);
 
     testcheck(buildId, couchdbURI).done(
         function onFulfilled(testResults) {
@@ -91,7 +91,7 @@ function main() {
 
                             // print the stack trace if it exists
                             if (typeof expectation.stack !== "undefined") {
-                                expectation.stack.split('\n').forEach(function (traceLine) {
+                                expectation.stack.split("\n").forEach(function (traceLine) {
                                     console.log(INDENT + INDENT + INDENT + traceLine);
                                 });
                             }

--- a/medic/medic-checkout.js
+++ b/medic/medic-checkout.js
@@ -35,7 +35,7 @@ function cloneProject(projectName, projectsConfig) {
 
     var project  = projectsConfig[projectName];
     var codebase = project.codebases[project.codebase];
-    var command  = "git clone " + codebase.repo + " --branch=" + codebase.branch + " --depth 1"
+    var command  = "git clone " + codebase.repo + " --branch=" + codebase.branch + " --depth 1";
 
     shelljs.exec(command, {silent: false, async: true}, function (returnCode, output) {
         if (returnCode !== 0) {

--- a/medic/medic-clean.js
+++ b/medic/medic-clean.js
@@ -50,15 +50,33 @@ function main() {
 
     // get args
     var argv = optimist
-        .usage("Usage: $0 --exclude {name[,name[,...]]}")
+        .usage("Usage: $0 PATH --exclude NAME [--exclude NAME [...]]")
+        .demand(1)
         .argv;
 
-    var excludeString = argv.exclude;
-    var excludedPaths = [".", ".."];
+    var root     = argv._[0];
+    var excludes = argv.exclude;
 
-    // parse excludes
-    if (argv.exclude) {
-        excludedPaths = excludedPaths.concat(excludeString.split(","));
+    // check for valid args
+    if (argv._.length > 1) {
+        util.fatal("can only clean one directory at a time, but " + argv._.length + " were passed");
+    }
+
+    // check for valid root
+    if (!fs.existsSync(root)) {
+        util.fatal(root + " does not exist");
+    } else {
+        shelljs.cd(root);
+    }
+
+    // compute excludes
+    var excludedPaths = [".", ".."];
+    if (typeof excludes !== "undefined") {
+        if (typeof excludes === "string") {
+            excludedPaths.push(excludes);
+        } else {
+            excludedPaths = excludedPaths.concat(excludes);
+        }
     }
 
     // get all directories except excluded ones

--- a/medic/medic-kill.js
+++ b/medic/medic-kill.js
@@ -43,6 +43,7 @@ function tasksOnPlatform(platformName) {
             } else {
                 return ["emulator64-x86", "emulator64-arm", "adb"];
             }
+            break;
         case util.BLACKBERRY:
             return [];
         default:
@@ -52,12 +53,15 @@ function tasksOnPlatform(platformName) {
 
 function getKillCommand(taskNames) {
 
+    var cli;
+    var args;
+
     if (util.isWindows()) {
-        var cli  = "taskkill /F";
-        var args = taskNames.map(function (name) { return "/IM \"" + name + "\""; });
+        cli  = "taskkill /F";
+        args = taskNames.map(function (name) { return "/IM \"" + name + "\""; });
     } else {
-        var cli  = "killall -9";
-        var args = taskNames.map(function (name) { return "\"" + name + "\""; });
+        cli  = "killall -9";
+        args = taskNames.map(function (name) { return "\"" + name + "\""; });
     }
 
     return cli + " " + args.join(" ");

--- a/medic/medic-log.js
+++ b/medic/medic-log.js
@@ -23,11 +23,41 @@
 
 "use strict";
 
-var fs = require("fs");
-
 var shelljs  = require("shelljs");
 var optimist = require("optimist");
-var util     = require("../lib/util");
+
+var util = require("../lib/util");
+
+// helpers
+function logAndroid() {
+
+    var command = "adb logcat -d";
+
+    util.medicLog("running:");
+    util.medicLog("    " + command);
+
+    shelljs.exec(command, function (code, output) {
+        if (code > 0) {
+            util.fatal("Failed to run logcat command.");
+        }
+    });
+}
+
+function logBlackberry() {
+    return;
+}
+
+function logIOS() {
+    return;
+}
+
+function logWindows() {
+    return;
+}
+
+function logWP8() {
+    return;
+}
 
 // main
 function main() {
@@ -39,21 +69,29 @@ function main() {
     // command-specific args
     var argv = optimist
         .usage("Usage: $0 {platform}")
-        .demand('platform')
+        .demand("platform")
         .argv;
 
-    switch (argv.platform) {
+    var platform = argv.platform;
+
+    switch (platform) {
         case util.ANDROID:
-            var cmd = "adb logcat -d";
-            console.log("executing " + cmd);
-            shelljs.exec(cmd, function(code, output) {
-                if (code > 0) {
-                    util.fatal('Failed to run logcat command.');
-                }
-            });
+            logAndroid();
+            break;
+        case util.BLACKBERRY:
+            logBlackberry();
+            break;
+        case util.IOS:
+            logIOS();
+            break;
+        case util.WINDOWS:
+            logWindows();
+            break;
+        case util.WP8:
+            logWP8();
             break;
         default:
-            console.warn("Logging is unsupported for " + argv.platform);
+            console.warn("Logging is unsupported for " + platform);
             break;
     }
 }

--- a/medic/medic-run.js
+++ b/medic/medic-run.js
@@ -167,13 +167,13 @@ function changeAndroidLoadTimeout(appPath, timeout) {
 
 function setWindowsTargetStoreVersion(appPath, version) {
 
-    util.medicLog('setting target store version to ' + version);
+    util.medicLog("setting target store version to " + version);
 
     var configFile    = getConfigPath(appPath);
     var configContent = fs.readFileSync(configFile, util.DEFAULT_ENCODING);
 
-    var versionPreference = '    <preference name="windows-target-version" value="' + version + '" />';
-    configContent = configContent.replace('</widget>', versionPreference + '\r\n</widget>');
+    var versionPreference = "    <preference name=\"windows-target-version\" value=\"" + version + "\" />";
+    configContent = configContent.replace("</widget>", versionPreference + "\r\n</widget>");
 
     fs.writeFileSync(configFile, configContent, "utf8");
 }
@@ -215,25 +215,25 @@ function windowsSpecificPreparation(argv) {
     // patch WindowsStoreAppUtils script to allow app run w/out active desktop/remote session
     if (winVersion === "store80" || winVersion === "store") {
 
-        util.medicLog('Patching WindowsStoreAppUtils to allow app to be run in automated mode');
+        util.medicLog("Patching WindowsStoreAppUtils to allow app to be run in automated mode");
 
-        var platformPath   = path.join(appPath, 'platforms', 'windows');
-        var libPath        = path.join(platformPath, 'cordova', 'lib');
-        var appUtilsPath   = path.join(libPath, 'WindowsStoreAppUtils.ps1');
-        var srcScriptPath  = path.join('cordova-medic', 'lib', 'patches', 'EnableDebuggingForPackage.ps1');
-        var destScriptPath = path.join(libPath, 'EnableDebuggingForPackage.ps1');
+        var platformPath   = path.join(appPath, "platforms", "windows");
+        var libPath        = path.join(platformPath, "cordova", "lib");
+        var appUtilsPath   = path.join(libPath, "WindowsStoreAppUtils.ps1");
+        var srcScriptPath  = path.join(CORDOVA_MEDIC_DIR, "lib", "patches", "EnableDebuggingForPackage.ps1");
+        var destScriptPath = path.join(libPath, "EnableDebuggingForPackage.ps1");
 
         // copy over the patch
-        shelljs.cp('-f', srcScriptPath, libPath);
+        shelljs.cp("-f", srcScriptPath, libPath);
 
         // add extra code to patch
         shelljs.sed(
-            '-i',
+            "-i",
             /^\s*\$appActivator .*$/gim,
-            '$&\n' +
-            '    powershell ' + path.join(process.cwd(), destScriptPath) + ' $$ID\n' +
-            '    $Ole32 = Add-Type -MemberDefinition \'[DllImport("Ole32.dll")]public static extern int CoAllowSetForegroundWindow(IntPtr pUnk, IntPtr lpvReserved);\' -Name \'Ole32\' -Namespace \'Win32\' -PassThru\n' +
-            '    $Ole32::CoAllowSetForegroundWindow([System.Runtime.InteropServices.Marshal]::GetIUnknownForObject($appActivator), [System.IntPtr]::Zero)',
+            "$&\n" +
+            "    powershell " + path.join(process.cwd(), destScriptPath) + " $$ID\n" +
+            "    $Ole32 = Add-Type -MemberDefinition '[DllImport(\"Ole32.dll\")]public static extern int CoAllowSetForegroundWindow(IntPtr pUnk, IntPtr lpvReserved);' -Name 'Ole32' -Namespace 'Win32' -PassThru\n" +
+            "    $Ole32::CoAllowSetForegroundWindow([System.Runtime.InteropServices.Marshal]::GetIUnknownForObject($appActivator), [System.IntPtr]::Zero)",
             appUtilsPath
         );
     }
@@ -246,24 +246,24 @@ function wp8SpecificPreparation(argv) {
     var appPath = argv.app;
 
     // set permanent guid to prevent multiple installations
-    var guid         = '{8449DEEE-16EB-4A4A-AFCC-8446E8F06FF7}';
-    var manifestPath = path.join(appPath, 'platforms', 'wp8', 'Properties', 'WMAppManifest.xml');
-    var xml          = fs.readFileSync(manifestPath).toString().split('\n');
+    var guid         = "{8449DEEE-16EB-4A4A-AFCC-8446E8F06FF7}";
+    var manifestPath = path.join(appPath, "platforms", "wp8", "Properties", "WMAppManifest.xml");
+    var xml          = fs.readFileSync(manifestPath).toString().split("\n");
 
-    for (var i in xml) if (xml[i].indexOf('<App') != -1) {
-        if (xml[i].toLowerCase().indexOf('productid') != -1) {
-            var index = xml[i].toLowerCase().indexOf('productid');
-            var spaceIndex = xml[i].indexOf(' ', index);
-            var stringAsArray = xml[i].split('');
+    for (var i in xml) if (xml[i].indexOf("<App") != -1) {
+        if (xml[i].toLowerCase().indexOf("productid") != -1) {
+            var index = xml[i].toLowerCase().indexOf("productid");
+            var spaceIndex = xml[i].indexOf(" ", index);
+            var stringAsArray = xml[i].split("");
             stringAsArray.splice(index, spaceIndex - index);
-            xml[i] = stringAsArray.join('');
+            xml[i] = stringAsArray.join("");
         }
         xml[i] = xml[i].substr(0, xml[i].length - 1);
-        xml[i] += ' ProductID="' + guid + '">';
+        xml[i] += " ProductID=\"" + guid + "\">";
         break;
     }
 
-    fs.writeFileSync(manifestPath, xml.join('\n'));
+    fs.writeFileSync(manifestPath, xml.join("\n"));
 
     var extraArgs = "";
     return extraArgs;
@@ -338,7 +338,7 @@ function main() {
     util.medicLog("running:");
     util.medicLog("    " + buildCommand);
     var result = shelljs.exec(buildCommand, {silent: false, async: false});
-    if (result.code != 0 || CORDOVA_ERROR_PATTERN.test(result.output)) {
+    if (result.code !== 0 || CORDOVA_ERROR_PATTERN.test(result.output)) {
         util.fatal("build failed");
     }
 
@@ -348,7 +348,7 @@ function main() {
     util.medicLog("running:");
     util.medicLog("    " + runCommand);
     shelljs.exec(runCommand, {silent: false, async: true}, function (returnCode, output) {
-        if (returnCode != 0 || CORDOVA_ERROR_PATTERN.test(output)) {
+        if (returnCode !== 0 || CORDOVA_ERROR_PATTERN.test(output)) {
             util.fatal("run failed");
         }
     });

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
       "name": "Don Coleman",
       "email": "don.coleman@gmail.com"
     }
-  ]
+  ],
+  "scripts": {
+    "jshint": "jshint medic lib"
+  }
 }


### PR DESCRIPTION
CB-9196 Adding JSHint config for medic. Making medic-log return an error code. Making `medic-clean`'s `--exclude` flag repeatable. Making `medic-clean` take a target directory. Fixing JSHint-detected errors.