### PR TITLE
CB-8936 Gather 15 minutes of logs on Windows

### DIFF
--- a/medic/medic-log.js
+++ b/medic/medic-log.js
@@ -66,7 +66,7 @@ function logIOS() {
 function logWindows() {
     var logScriptPath = path.join("mobilespec", "platforms", "windows", "cordova", "log.bat");
     if (fs.existsSync(logScriptPath)) {
-        shelljs.exec(logScriptPath + " --dump", function (code, output) {
+        shelljs.exec(logScriptPath + " --dump --mins 15", function (code, output) {
             if (code > 0) {
                 util.fatal("Failed to run log command.");
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-8936

Currently we gather default 10 minutes of logs which is enough in general, but when build is timing out it takes about 12-13 minutes so we don't get the logs from starting minutes of the test run.