### PR TITLE
CB-9660 Don't kill emulators/apps after failed test run

### DIFF
--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -350,7 +350,7 @@ def cordova_steps_run_tests(platform, extra_args=list()):
                 '--timeout',  TEST_RUN_TIMEOUT - 60
             ] + extra_args,
             description   = 'running tests',
-            haltOnFailure = False,
+            haltOnFailure = True,
         ),
 
         SH(
@@ -364,6 +364,7 @@ def cordova_steps_run_tests(platform, extra_args=list()):
             timeout        = LOG_GETTING_TIMEOUT,
             haltOnFailure  = False,
             flunkOnFailure = False,
+            alwaysRun      = True,
         ),
 
         SH(


### PR DESCRIPTION
Also don't try to get test results and count failed tests.

https://issues.apache.org/jira/browse/CB-9660