### PR TITLE
CB-9759 Link cordova-common -> cordova-lib to prevent `npm install` failures

### DIFF
--- a/buildbot-conf/cordova.conf
+++ b/buildbot-conf/cordova.conf
@@ -281,6 +281,7 @@ CORDOVA_STEPS_GET_TOOLS = [
 
     # install lib
     NPMLink(command=['cordova-js'], workdir='cordova-lib/cordova-lib', what='cloned cordova-js'),
+    NPMLink(command=['../cordova-common'], workdir='cordova-lib/cordova-lib', what='linked cordova-common'),
     NPMInstall(workdir='cordova-lib/cordova-lib', what='cordova-lib'),
     NPMLink(workdir='cordova-lib/cordova-lib', what='cordova-lib'),
 


### PR DESCRIPTION
This fixes Buildbot failure, described in [CB-9759](https://issues.apache.org/jira/browse/CB-9759)
@dblotsky, could you please review and apply this configuration to Buildbot