### PR TITLE
CB-10390: ADB doesn't recognize existing devices in Medic

### DIFF
--- a/medic/medic-log.js
+++ b/medic/medic-log.js
@@ -31,7 +31,8 @@ var path     = require("path");
 var util = require("../lib/util");
 
 // constants
-var DEVICE_ROW_PATTERN = / (emulator|device|host) /m;
+var DEVICE_ROW_PATTERN = /(emulator|device|host)/m;
+var HEADING_LINE_PATTERN = /List of devices/m;
 
 // helpers
 function logAndroid() {
@@ -46,7 +47,7 @@ function logAndroid() {
     var numDevices = 0;
     var result = shelljs.exec(listCommand, {silent: false, async: false});
     result.output.split('\n').forEach(function (line) {
-        if (DEVICE_ROW_PATTERN.test(line)) {
+        if (!HEADING_LINE_PATTERN.test(line) && DEVICE_ROW_PATTERN.test(line)) {
             numDevices += 1;
         }
     });


### PR DESCRIPTION
In Apache CI, we get the error: ADB doesn't recognize existing devices
in Medic. The root cause for this error is that there is an additional
space in the pattern. As a result ‘emulator-5554’ will not be matched
with ‘emulator ‘ pattern (due to additional space). On removing the
additional space, the pattern matching working fine.

Also, when you run adb devices command, there will be a header line
“List of devices” will be displayed which must be ignored. Added the
code to ignore that also.