### PR TITLE
CB-10433: Removing the ETIMEDOUT errors in medic-run

### DIFF
--- a/lib/testwait.js
+++ b/lib/testwait.js
@@ -25,6 +25,8 @@ var q = require("q");
 
 var couchdb = require("./couchdb");
 
+var util = require("./util");
+
 var mobilespec_results = null;
 
 function init(uri) {
@@ -37,7 +39,6 @@ function query_for_sha(sha, callback) {
     // get build errors from couch for each repo
     mobilespec_results.query_view("results", view, function(error, result) {
         if (error) {
-            console.error("query failed for mobilespec_results", error);
             callback(true, error);
             return;
         }
@@ -48,22 +49,39 @@ function query_for_sha(sha, callback) {
 function isTestsCompleted(sha, callback) {
     query_for_sha(sha, function (isFailed, res) {
         // return True if there is no error and there are test results in db for specified sha
-        callback(!isFailed && res.rows.length > 0);
+        callback(!isFailed && res.rows.length > 0, !isFailed);
     });
 }
 
-function waitTestsCompleted(sha, timeoutMs) {
+function waitTestsCompleted(sha, timeoutMs, silent) {
 
     var defer          = q.defer();
     var startTime      = Date.now();
     var timeoutTime    = startTime + timeoutMs;
     var checkInterval  = 10 * 1000; // 10 secs
 
+    // Stats for reporting
+    var totalChecks = 0;
+    var badChecks = 0;
+
     var testFinishedFn = setInterval(function () {
-        isTestsCompleted(sha, function (isSuccess) {
+        isTestsCompleted(sha, function (isSuccess, requestSuccess) {
+            totalChecks = totalChecks + 1;
+            if (!requestSuccess) {
+                badChecks = badChecks + 1;
+            }
+
             // if tests are finished or timeout
             if (isSuccess || Date.now() > timeoutTime) {
                 clearInterval(testFinishedFn);
+
+                if (!silent) {
+                    util.medicLog("Finished polling for mobilespec results.");
+                    util.medicLog("    Results Found:   " + isSuccess);
+                    util.medicLog("    Total attempts:  " + totalChecks);
+                    util.medicLog("    Failed attempts: " + badChecks);
+                }
+
                 if (isSuccess) {
                     defer.resolve();
                 } else {

--- a/medic/medic-kill.js
+++ b/medic/medic-kill.js
@@ -39,9 +39,9 @@ function tasksOnPlatform(platformName) {
             return ["iOS Simulator"];
         case util.ANDROID:
             if (util.isWindows()) {
-                return ["emulator-arm.exe", "adb.exe"];
+                return ["emulator-arm.exe"];
             } else {
-                return ["emulator64-x86", "emulator64-arm", "adb"];
+                return ["emulator64-x86", "emulator64-arm"];
             }
             break;
         case util.BLACKBERRY:
@@ -85,20 +85,10 @@ function killTasks(taskNames) {
     });
 }
 
-// main
-function main() {
-
+function killTasksForPlatform(platform) {
     // shell config
     shelljs.config.fatal  = false;
     shelljs.config.silent = false;
-
-    // get args
-    var argv = optimist
-        .usage("Usage: $0 --platform {platform}")
-        .demand("platform")
-        .argv;
-
-    var platform = argv.platform;
 
     // get platform tasks
     var platformTasks = tasksOnPlatform(platform);
@@ -111,4 +101,20 @@ function main() {
     killTasks(platformTasks);
 }
 
-main();
+// main
+function main() {
+    // get args
+    var argv = optimist
+        .usage("Usage: $0 --platform {platform}")
+        .demand("platform")
+        .argv;
+
+    killTasksForPlatform(argv.platform);
+}
+
+module.exports = killTasksForPlatform;
+
+// This script can be required or run directly
+if (require.main === module) {
+    main();
+}

--- a/medic/medic-run.js
+++ b/medic/medic-run.js
@@ -378,7 +378,7 @@ function main() {
                 process.exit(0);
             },
             function onRejected(error) {
-                console.error("Could not find test results: " + error);
+                console.error("Could not find test results. Check the output of medic-log to see if the app crashed before it could upload them to couchdb.");
                 process.exit(1);
             }
         );

--- a/medic/medic-run.js
+++ b/medic/medic-run.js
@@ -350,7 +350,7 @@ function main() {
     }
 
     tryConnect(couchdbURI, MAX_NUMBER_OF_TRIES, function (){
-        util.medicLog("it's up");        
+        util.medicLog("it's up");
 
         // modify the app to run autonomously
         createMedicJson(appPath, buildId, couchdbURI);
@@ -372,13 +372,13 @@ function main() {
         //      timeout needs to be in milliseconds, but it's
         //      given in seconds, so we multiply by 1000
         testwait.init(couchdbURI);
-        testwait.waitTestsCompleted(buildId, timeout * 1000).then(
+        testwait.waitTestsCompleted(buildId, timeout * 1000, false).then(
             function onFulfilled(value) {
-                util.medicLog("got test results");
+                util.medicLog("Successfully found test results");
                 process.exit(0);
             },
             function onRejected(error) {
-                console.error("didn't get test results: " + error);
+                console.error("Could not find test results: " + error);
                 process.exit(1);
             }
         );


### PR DESCRIPTION
Occasionally, requests to couchdb fail for mysterious reasons when medic-run does its polling for mobilespec results. These were being reported a lot as the cause of CI issues, but in fact they are not. Only a few requests fail out of multiple poll attempts and sometimes these messages show up in successful runs. This removes the annoying ETIMEDOUT messages and replaces them with brief stats at the end of the polling.

@dblotsky @nikhilkh @rakatyal please review.