### PR TITLE
CB-10540: Changing request call to non-streaming version

### DIFF
--- a/medic/medic-run.js
+++ b/medic/medic-run.js
@@ -263,24 +263,27 @@ function failedBecauseNoDevice(output) {
 
 function tryConnect(couchdbURI, pendingNumberOfTries, callback) {
     util.medicLog("checking if " + couchdbURI + " is up.");
-
+       
     // check if results server is up
     request({
         uri:     couchdbURI,
         method:  "GET",
         timeout: SERVER_RESPONSE_TIMEOUT
-    }).on('response', function (response){
-        callback();
-    }).on('error', function (error){
-        if(pendingNumberOfTries > 1) {
-            util.medicLog("it's not up. Going to retry after " + WAIT_TIME_TO_RETRY_CONNECTION + " milliseconds");
-            setTimeout(function (){
-                tryConnect(couchdbURI, pendingNumberOfTries-1 , callback);
-            }, WAIT_TIME_TO_RETRY_CONNECTION);
-        } else {
-            util.fatal("it's not up even after " + MAX_NUMBER_OF_TRIES + " attempts to connect, so test run can't be monitored");
-            process.exit(1);
+    }, function (error, response, body){
+        if(error) {
+            if(pendingNumberOfTries > 1) {
+                util.medicLog("it's not up. Going to retry after " + WAIT_TIME_TO_RETRY_CONNECTION + " milliseconds");
+                setTimeout(function (){
+                    tryConnect(couchdbURI, pendingNumberOfTries-1 , callback);
+                }, WAIT_TIME_TO_RETRY_CONNECTION);
+            } else {
+                util.fatal("it's not up even after " + MAX_NUMBER_OF_TRIES + " attempts to connect, so test run can't be monitored");
+                process.exit(1);
+            }
         }
+        else {
+            callback();
+        }      
     });
 }
 


### PR DESCRIPTION
We were using the streaming request before which sometimes caused the error method to call in between the response method call when the connection dropped, causing the failures.