### PR TITLE
CB-10671 and CB-10699: Android Windows CI fixes for logging and run

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -24,11 +24,14 @@
 module.exports = (function () {
 
     var os = require("os");
+    var shelljs = require("shelljs");
 
     // constants
     var ESCAPE    = String.fromCharCode(27);
     var RED_COLOR = ESCAPE + "[31m";
     var NO_COLOR  = ESCAPE + "[m";
+    var DEVICE_ROW_PATTERN = /(emulator|device|host)/m;
+    var HEADING_LINE_PATTERN = /List of devices/m;
 
     function medicLog(message) {
         console.log(RED_COLOR + "[MEDIC LOG " + new Date().toUTCString() + "]" + NO_COLOR + " " + message);
@@ -54,6 +57,23 @@ module.exports = (function () {
         return Math.ceil(seconds / 60);
     }
 
+    function countAndroidDevices() {
+        var listCommand = "adb devices";
+
+        medicLog("running:");
+        medicLog("    " + listCommand);
+
+        var numDevices = 0;
+        var result = shelljs.exec(listCommand, {silent: false, async: false});
+        result.output.split('\n').forEach(function (line) {
+            if (!HEADING_LINE_PATTERN.test(line) && DEVICE_ROW_PATTERN.test(line)) {
+                numDevices += 1;
+            }
+        });
+
+        return numDevices;
+    }
+
     return {
 
         // constants
@@ -71,6 +91,7 @@ module.exports = (function () {
         isWindows: isWindows,
         medicLog:  medicLog,
         contains:  contains,
-        secToMin:  secToMin
+        secToMin:  secToMin,
+        countAndroidDevices: countAndroidDevices
     };
 }());

--- a/medic/medic-kill.js
+++ b/medic/medic-kill.js
@@ -49,6 +49,24 @@ function tasksOnPlatform(platformName) {
     }
 }
 
+/**
+ * CB-10671: In order to deal with issues where "ghost" emulators sometimes get
+ * left behind, we kill the ADB server
+ */
+function killAdbServer() {
+    util.medicLog("Killing adb server");
+    var killServerCommand = "adb kill-server";
+
+    util.medicLog("Running the following command:");
+    util.medicLog("    " + killServerCommand);
+
+    var killServerResult = shelljs.exec(killServerCommand, {silent: false, async: false});
+    if (killServerResult.code !== 0) {
+        util.fatal("Failed killing adb server");
+    }
+    util.medicLog("Finished killing adb server");
+}
+
 function getKillCommand(taskNames) {
 
     var cli;
@@ -76,11 +94,10 @@ function killTasks(taskNames) {
     util.medicLog("running the following command:");
     util.medicLog("    " + command);
 
-    shelljs.exec(command, {silent: false, async: true}, function (returnCode, output) {
-        if (returnCode !== 0) {
-            console.warn("WARNING: kill command returned " + returnCode);
-        }
-    });
+    var killTasksResult = shelljs.exec(command, {silent: false, async: false });
+    if (killTasksResult.code !== 0) {
+        console.warn("WARNING: kill command returned " + killTasksResult.code);
+    }
 }
 
 function killTasksForPlatform(platform) {
@@ -97,6 +114,10 @@ function killTasksForPlatform(platform) {
 
     // kill them
     killTasks(platformTasks);
+
+    if (platform === util.ANDROID) {
+        killAdbServer();
+    }
 }
 
 // main

--- a/medic/medic-log.js
+++ b/medic/medic-log.js
@@ -31,27 +31,15 @@ var path     = require("path");
 var util = require("../lib/util");
 
 // constants
-var DEVICE_ROW_PATTERN = /(emulator|device|host)/m;
-var HEADING_LINE_PATTERN = /List of devices/m;
 var DEFAULT_APP_PATH = "mobilespec";
 
 // helpers
 function logAndroid() {
 
     var logCommand = "adb logcat -d";
-    var listCommand = "adb devices";
-
-    util.medicLog("running:");
-    util.medicLog("    " + listCommand);
 
     // bail out if there is more/less than one device
-    var numDevices = 0;
-    var result = shelljs.exec(listCommand, {silent: false, async: false});
-    result.output.split('\n').forEach(function (line) {
-        if (!HEADING_LINE_PATTERN.test(line) && DEVICE_ROW_PATTERN.test(line)) {
-            numDevices += 1;
-        }
-    });
+    var numDevices = util.countAndroidDevices();
     if (numDevices != 1) {
         util.fatal("there must be exactly one emulator/device attached");
     }

--- a/medic/medic-run.js
+++ b/medic/medic-run.js
@@ -423,6 +423,26 @@ function main() {
                     util.fatal("Could not start Android emulator");
                 } else {
                     util.medicLog("Android emulator started");
+
+                    // CB-10699: We try to uninstall the app once the emulator
+                    // boots up, because sometimes the adb command that "cordova
+                    // run" uses fails to uninstall the app and errors out
+
+                    // There needs to be only one device for uninstall to work
+                    var numDevices = util.countAndroidDevices();
+                    if (numDevices != 1) {
+                        util.medicLog("WARNING: There is more than one device/emulator attached, skipping uninstall step");
+                    } else {
+                        var uninstallCommand = "adb uninstall org.apache.mobilespec";
+
+                        util.medicLog("Running the following command:");
+                        util.medicLog("    " + uninstallCommand);
+
+                        // This command will fail if the app is not installed,
+                        // so we set it to silent so as to not confuse anyone
+                        var uninstallResult = shelljs.exec(uninstallCommand, {silent: true, async: false});
+                    }
+
                     runOnEmulator();
                 }
             } else {


### PR DESCRIPTION
This addresses two JIRAs: [CB-10671](https://issues.apache.org/jira/browse/CB-10671) and [CB-10699](https://issues.apache.org/jira/browse/CB-10699). I am submitting this as one PR rather than two because CB-10699 was somewhat blocked on CB-10671.

The CB-10671 fix adds the command `adb kill-server` to medic-kill for Android so as to clear out all of the mysterious "host" emulators that have been cropping up and causing medic-log to fail. Not sure what is causing those entries to appear (and only on Windows), but this seems to get rid of them

The CB-10699 fix tries to uninstall mobilespec before using `cordova run` because the command that `cordova run` uses to install the app sometimes fails if the app will not uninstall. That causes the run step to fail (and every run step thereafter until someone uninstalls the app).

@sarangan12 @dblotsky please review.