### PR TITLE
CB-10898 Kill iOS Simulator, Xcode7 style

### DIFF
--- a/medic/medic-kill.js
+++ b/medic/medic-kill.js
@@ -34,7 +34,7 @@ function tasksOnPlatform(platformName) {
         case util.WINDOWS:
             return ["WWAHost.exe", "Xde.exe"];
         case util.IOS:
-            return ["iOS Simulator"];
+            return ["Simulator"];
         case util.ANDROID:
             if (util.isWindows()) {
                 return ["emulator-arm.exe"];


### PR DESCRIPTION
With Xcode7, the way to kill the simulator is now by running: "killall -9 Simulator".
For details, see: https://issues.apache.org/jira/browse/CB-10898