### PR TITLE
Ensure Android adb logs have timestamp

### DIFF
--- a/medic/medic-log.js
+++ b/medic/medic-log.js
@@ -35,8 +35,8 @@ var DEFAULT_APP_PATH = "mobilespec";
 
 // helpers
 function logAndroid() {
-
-    var logCommand = "adb logcat -d";
+    
+    var logCommand = "adb logcat -d -v time";
 
     // bail out if there is more/less than one device
     var numDevices = util.countAndroidDevices();


### PR DESCRIPTION
This should help in debugging as it will have timestamps for native logs. @riknoll, @sarangan12  to take a look. We should do the same with paramedic if we have similar code.