### PR TITLE
CB-11168: Fix the appName in cordova-medic

### DIFF
--- a/medic/medic-run.js
+++ b/medic/medic-run.js
@@ -254,7 +254,7 @@ function iOSSpecificPreparation(argv) {
 
     util.medicLog("Granting iOS permissions: ");
 
-    var appName = argv.app;
+    var appName = 'org.apache.mobilespec';
     var simulatorsFolder = argv.simulatorsFolder;
     var tccDbPath = argv.tccDbPath;
 


### PR DESCRIPTION
The appName is just set to incorrect value. The appName must be 'org.apache.mobilespec'. But, when it is picked from command line arguments, which is just 'mobilespec', it is incorrect. Fixing the issue in this PR. 

@omefire Can you please review and merge this PR?