### PR TITLE
Appium updates

### DIFF
--- a/lib/appium/helpers/wdHelper.js
+++ b/lib/appium/helpers/wdHelper.js
@@ -51,7 +51,6 @@ module.exports.getDriver = function (platform) {
     };
 
     var driverConfig = {
-        browserName: '',
         platformName: normalizedPlatform,
         platformVersion: global.PLATFORM_VERSION || '',
         deviceName: global.DEVICE_NAME || '',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "medic": "./medic/medic.js"
   },
   "dependencies": {
-    "appium": "^1.5.0",
+    "appium": "^1.5.3",
     "commander": "^2.8.1",
     "elementtree": "^0.1.6",
     "expect-telnet": "^0.5.2",


### PR DESCRIPTION
Please review @alsorokin !

### Platforms affected

iOS and Android

### What does this PR do?

Fixes and cleans up certain interactions with appium:
 - Appium version bumped
 - Desired capabilities in Selenium-land (and thus Appium) is usually tricky and obtuse. Clarified some usage of it as well as forcing string for `platformVersion`. Removed `browserName` completely as it is not applicable to hybrid apps.
 - I removed the `setTimeout`s around process killing, as on my Mac w/ node v6.9.1 that would lead to improper termination of the appium process. I defer to you, @alsorokin, on whether that is a good change or not.

### What testing has been done on this change?

Tested on Android 5.1 emulator w/ contacts plugin appium tests.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
